### PR TITLE
zig: M4 Phase 4b - cross-namespace generic instantiation registry

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1152,23 +1152,22 @@ pub fn build(b: *std.Build) void {
         "Windows.Web.Http.Headers",
     };
 
-    // Cross-namespace generic instantiation seeds (M4 Phase 4b/4c).
-    const bundle_seeds = [_]struct { ns: []const u8, seed: []const u8 }{
-        .{ .ns = "Windows.Foundation.Collections", .seed = "--seed=IVectorView`1,string" },
-        .{ .ns = "Windows.Foundation.Collections", .seed = "--seed=IIterable`1,string" },
-        .{ .ns = "Windows.Foundation.Collections", .seed = "--seed=IIterator`1,string" },
-    };
+    // M4 Phase 4b: a single `winbindgen bundle` invocation emits every
+    // namespace in the bundle and auto-routes closed-generic
+    // instantiations (e.g. `IVectorView``1<HSTRING>` reached from
+    // Windows.Globalization) into their home namespace. Replaces the
+    // per-namespace loop + hand-coded --seed= flags.
+    const bundle_run = b.addRunArtifact(winbindgen_exe);
+    bundle_run.addArg("bundle");
+    if (arch_flag) |f| bundle_run.addArg(f);
+    bundle_run.addArg("--outdir");
+    const bundle_outdir = bundle_run.addOutputDirectoryArg("bundle");
+    for (bundle_namespaces) |ns| bundle_run.addArg(ns);
 
     const bundle_wf = b.addWriteFiles();
     for (bundle_namespaces) |ns| {
-        const gen_run = b.addRunArtifact(winbindgen_exe);
-        if (arch_flag) |f| gen_run.addArg(f);
-        for (bundle_seeds) |s| {
-            if (std.mem.eql(u8, s.ns, ns)) gen_run.addArg(s.seed);
-        }
-        gen_run.addArg(ns);
-        const gen_source = gen_run.captureStdOut(.{});
-        _ = bundle_wf.addCopyFile(gen_source, b.fmt("{s}.zig", .{ns}));
+        const src = bundle_outdir.path(b, b.fmt("{s}.zig", .{ns}));
+        _ = bundle_wf.addCopyFile(src, b.fmt("{s}.zig", .{ns}));
     }
 
     // Use the first namespace as the root of the bundle module; sibling

--- a/zig/packages/winbindgen/src/main.zig
+++ b/zig/packages/winbindgen/src/main.zig
@@ -361,39 +361,40 @@ fn runBundle(
         std.process.exit(2);
     }
 
-    // All input namespaces must resolve to the same winmd file. Pick
-    // the file based on the first namespace; reject any namespace that
-    // doesn't match.
-    const first_bytes = selectBytes(namespaces.items[0]);
-    for (namespaces.items[1..]) |ns| {
-        if (selectBytes(ns).ptr != first_bytes.ptr) {
-            try stderr.print(
-                "bundle: mixed metadata files — {s} and {s} come from different .winmd\n",
-                .{ namespaces.items[0], ns },
-            );
-            try stderr.flush();
-            std.process.exit(2);
-        }
+    // Group namespaces by which winmd file they resolve to; cross-ns
+    // generic routing happens only within the same winmd. Phase 4b's
+    // WinRT-only routing is a natural fit for this grouping because the
+    // Windows.winmd group is where all closed generics live.
+    var groups: std.AutoArrayHashMapUnmanaged([*]const u8, std.ArrayListUnmanaged([]const u8)) = .empty;
+    for (namespaces.items) |ns| {
+        const bytes = selectBytes(ns);
+        const gop = try groups.getOrPut(arena, bytes.ptr);
+        if (!gop.found_existing) gop.value_ptr.* = .empty;
+        try gop.value_ptr.append(arena, ns);
     }
-
-    var file = try winmd.parse(first_bytes);
-    const emission = try winbindgen.emitBundle(arena, &file, namespaces.items, arch);
 
     var dir = try std.Io.Dir.cwd().createDirPathOpen(io, dir_path, .{});
     defer dir.close(io);
 
-    // Write each namespace's bytes to <outdir>/<ns>.zig. Use gpa-backed
-    // buffered writer to avoid arena peak bloat on many small files.
-    for (namespaces.items) |ns| {
-        const bytes = emission.get(ns) orelse continue;
-        const file_name = try std.fmt.allocPrint(arena, "{s}.zig", .{ns});
-        var out_file = try dir.createFile(io, file_name, .{});
-        defer out_file.close(io);
+    var git = groups.iterator();
+    while (git.next()) |entry| {
+        const group_ns = entry.value_ptr.items;
+        const group_bytes = selectBytes(group_ns[0]);
 
-        var out_buf: [4096]u8 = undefined;
-        var out_writer = out_file.writer(io, &out_buf);
-        try out_writer.interface.writeAll(bytes);
-        try out_writer.interface.flush();
+        var file = try winmd.parse(group_bytes);
+        const emission = try winbindgen.emitBundle(arena, &file, group_ns, arch);
+
+        for (group_ns) |ns| {
+            const bytes = emission.get(ns) orelse continue;
+            const file_name = try std.fmt.allocPrint(arena, "{s}.zig", .{ns});
+            var out_file = try dir.createFile(io, file_name, .{});
+            defer out_file.close(io);
+
+            var out_buf: [4096]u8 = undefined;
+            var out_writer = out_file.writer(io, &out_buf);
+            try out_writer.interface.writeAll(bytes);
+            try out_writer.interface.flush();
+        }
     }
 
     // Suppress-unused-warning; gpa currently only needed for future

--- a/zig/packages/winbindgen/src/main.zig
+++ b/zig/packages/winbindgen/src/main.zig
@@ -64,6 +64,25 @@ pub fn main(init: std.process.Init) !void {
         return;
     }
 
+    // `bundle --outdir <dir> [--arch=...] ns1 ns2 ...` emits a batch
+    // of namespaces as a coordinated bundle, auto-routing
+    // cross-namespace closed-generic instantiations to their home
+    // namespace. Writes `<outdir>/<ns>.zig` for each input.
+    //
+    // All input namespaces must resolve to the same metadata file —
+    // closed generics today are WinRT-only, so this is the Phase 4b
+    // path for `Windows.winmd`.
+    if (args.len >= 2 and std.mem.eql(u8, args[1], "bundle")) {
+        try runBundle(
+            init.arena.allocator(),
+            gpa,
+            io,
+            args[2..],
+            stderr,
+        );
+        return;
+    }
+
     // `--emit-mod <dir>` scans <dir> for sibling `*.structs.zig` and
     // `*.index.zig` generated files and prints a `mod.zig` to stdout
     // that re-exports them by namespace. This retires the hand-edited
@@ -279,4 +298,105 @@ fn emitMod(
 
 fn stringLessThan(_: void, a: []const u8, b: []const u8) bool {
     return std.mem.lessThan(u8, a, b);
+}
+
+/// Handle the `bundle --outdir <dir> [--arch=...] ns1 ns2 ...` subcommand.
+/// Calls `winbindgen.emitBundle` to emit every input namespace in a single
+/// coordinated pass (cross-namespace closed generics auto-route to their
+/// home namespace), then writes `<outdir>/<ns>.zig` for each result.
+fn runBundle(
+    arena: std.mem.Allocator,
+    gpa: std.mem.Allocator,
+    io: std.Io,
+    args: []const []const u8,
+    stderr: *std.Io.Writer,
+) !void {
+    var arch: winbindgen.Arch = .x64;
+    var outdir: ?[]const u8 = null;
+    var namespaces = try std.ArrayList([]const u8).initCapacity(arena, 0);
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const a = args[i];
+        if (std.mem.startsWith(u8, a, "--arch=")) {
+            const v = a["--arch=".len..];
+            if (std.mem.eql(u8, v, "x86")) {
+                arch = .x86;
+            } else if (std.mem.eql(u8, v, "x64")) {
+                arch = .x64;
+            } else if (std.mem.eql(u8, v, "arm64")) {
+                arch = .arm64;
+            } else {
+                try stderr.print("unknown --arch value: {s}\n", .{v});
+                try stderr.flush();
+                std.process.exit(2);
+            }
+        } else if (std.mem.startsWith(u8, a, "--outdir=")) {
+            outdir = a["--outdir=".len..];
+        } else if (std.mem.eql(u8, a, "--outdir")) {
+            i += 1;
+            if (i >= args.len) {
+                try stderr.writeAll("--outdir requires a path argument\n");
+                try stderr.flush();
+                std.process.exit(2);
+            }
+            outdir = args[i];
+        } else {
+            try namespaces.append(arena, a);
+        }
+    }
+
+    const dir_path = outdir orelse {
+        try stderr.writeAll(
+            \\usage: winbindgen bundle --outdir <dir> [--arch=x86|x64|arm64] ns1 ns2 ...
+            \\
+        );
+        try stderr.flush();
+        std.process.exit(2);
+    };
+
+    if (namespaces.items.len == 0) {
+        try stderr.writeAll("bundle: need at least one namespace\n");
+        try stderr.flush();
+        std.process.exit(2);
+    }
+
+    // All input namespaces must resolve to the same winmd file. Pick
+    // the file based on the first namespace; reject any namespace that
+    // doesn't match.
+    const first_bytes = selectBytes(namespaces.items[0]);
+    for (namespaces.items[1..]) |ns| {
+        if (selectBytes(ns).ptr != first_bytes.ptr) {
+            try stderr.print(
+                "bundle: mixed metadata files — {s} and {s} come from different .winmd\n",
+                .{ namespaces.items[0], ns },
+            );
+            try stderr.flush();
+            std.process.exit(2);
+        }
+    }
+
+    var file = try winmd.parse(first_bytes);
+    const emission = try winbindgen.emitBundle(arena, &file, namespaces.items, arch);
+
+    var dir = try std.Io.Dir.cwd().createDirPathOpen(io, dir_path, .{});
+    defer dir.close(io);
+
+    // Write each namespace's bytes to <outdir>/<ns>.zig. Use gpa-backed
+    // buffered writer to avoid arena peak bloat on many small files.
+    for (namespaces.items) |ns| {
+        const bytes = emission.get(ns) orelse continue;
+        const file_name = try std.fmt.allocPrint(arena, "{s}.zig", .{ns});
+        var out_file = try dir.createFile(io, file_name, .{});
+        defer out_file.close(io);
+
+        var out_buf: [4096]u8 = undefined;
+        var out_writer = out_file.writer(io, &out_buf);
+        try out_writer.interface.writeAll(bytes);
+        try out_writer.interface.flush();
+    }
+
+    // Suppress-unused-warning; gpa currently only needed for future
+    // large-file buffers.
+    _ = gpa;
 }

--- a/zig/packages/winbindgen/src/root.zig
+++ b/zig/packages/winbindgen/src/root.zig
@@ -40,6 +40,26 @@ const CrossNsSet = std.StringArrayHashMapUnmanaged(void);
 /// row and emits substituted `<Mangled>` + `<Mangled>_Vtbl` structs.
 pub const GenericInstSet = std.StringArrayHashMapUnmanaged(winmd.TypeName);
 
+/// M4 Phase 4b cross-namespace generic instantiation registry.
+///
+/// Map from home-namespace → set of closed-generic instantiations
+/// whose open definition lives in that namespace. Built by
+/// `discoverCrossNsGenerics` in a pre-pass over every namespace's
+/// method sigs. Consumed by a bundle driver which routes each
+/// per-namespace set into the corresponding `emitNamespaceEx` call
+/// via the `extra_insts` parameter.
+///
+/// Motivation: the v0.1 emitter only registers closed generics whose
+/// open def lives in the currently-emitting namespace. A method sig
+/// like `Calendar.Languages → IVectorView\`1<HSTRING>` references an
+/// open def (`IVectorView\`1`) that lives in a *different* namespace
+/// (`Windows.Foundation.Collections`). Without routing, that instantiation
+/// never gets emitted anywhere, and `writeZigTy` falls back to
+/// `*anyopaque`. Phase 4b closes this loop: each source namespace's
+/// sigs are pre-scanned for cross-namespace closed generics, and each
+/// discovered key is routed to its home namespace for emission.
+pub const PendingGenericMap = std.StringArrayHashMapUnmanaged(GenericInstSet);
+
 /// Is `ns` a namespace we are willing to emit a cross-namespace
 /// import alias for?  Today only `Windows.*` (and the bare root
 /// `Windows`) qualify — `System.Guid`, `System.Object`, etc. are
@@ -1715,6 +1735,98 @@ fn collectInstFromTy(
         .ref_const => |inner| try collectInstFromTy(insts, arena, inner.*, home_namespace),
         .array => |inner| try collectInstFromTy(insts, arena, inner.*, home_namespace),
         .array_fixed => |a| try collectInstFromTy(insts, arena, a.inner.*, home_namespace),
+        else => {},
+    }
+}
+
+/// M4 Phase 4b: discover every closed-generic instantiation referenced
+/// by method signatures in `source_namespace` whose open TypeDef lives
+/// in a *different* namespace. Groups them by home namespace and
+/// appends to `out` (creating per-ns `GenericInstSet`s on demand).
+///
+/// This is the Phase 4b discovery pre-pass. A bundle driver calls this
+/// for each namespace it plans to emit, then routes each collected
+/// per-home-namespace set into that home namespace's `emitNamespaceEx`
+/// call via `extra_insts`. Without this routing, a reference like
+/// `Calendar.Languages → IVectorView\`1<HSTRING>` would never see its
+/// closed-generic handle emitted anywhere in the bundle, because
+/// `collectGenericInstantiations` only registers open defs whose home
+/// matches the currently-emitting namespace.
+///
+/// Only instantiations whose arg Tys are all `isMangleableArg` are
+/// recorded (primitives plus class/value refs); everything else is
+/// still out of scope for v0.1.
+pub fn discoverCrossNsGenerics(
+    out: *PendingGenericMap,
+    arena: std.mem.Allocator,
+    file: *const winmd.File,
+    source_namespace: []const u8,
+) !void {
+    const rows = file.rowCount(.type_def);
+    var row: u32 = 0;
+    while (row < rows) : (row += 1) {
+        if (!std.mem.eql(u8, file.str(.type_def, row, 2), source_namespace)) continue;
+
+        const methods = file.list(.type_def, row, 5, .method_def);
+        var m = methods.start;
+        while (m < methods.end) : (m += 1) {
+            const sig_blob = file.blob(.method_def, m, 4);
+            const sig = winmd.readMethodSignature(arena, file, sig_blob) catch continue;
+
+            try collectCrossNsInstFromTy(out, arena, sig.return_type, source_namespace);
+            for (sig.params) |p| {
+                try collectCrossNsInstFromTy(out, arena, p, source_namespace);
+            }
+        }
+    }
+}
+
+/// Walk a `Ty` tree and register any closed-generic instantiation
+/// whose home namespace differs from `source_namespace`. The key is
+/// inserted into `out[tn.namespace]`. Recurses into pointer/ref/array
+/// wrappers and nested generic args.
+fn collectCrossNsInstFromTy(
+    out: *PendingGenericMap,
+    arena: std.mem.Allocator,
+    ty: winmd.Ty,
+    source_namespace: []const u8,
+) !void {
+    switch (ty) {
+        .class_name, .value_name => |tn| {
+            if (std.mem.indexOfScalar(u8, tn.name, '`') != null and
+                tn.generics.len > 0 and
+                !std.mem.eql(u8, tn.namespace, source_namespace) and
+                isProjectableNs(tn.namespace))
+            {
+                var all_mangleable = true;
+                for (tn.generics) |a| {
+                    if (!isMangleableArg(a)) {
+                        all_mangleable = false;
+                        break;
+                    }
+                }
+                if (all_mangleable) {
+                    const key = try mangleInstAlloc(arena, tn.name, tn.generics);
+                    const home_key = try arena.dupe(u8, tn.namespace);
+                    const gop = try out.getOrPut(arena, home_key);
+                    if (!gop.found_existing) gop.value_ptr.* = .empty;
+                    if (!gop.value_ptr.contains(key)) {
+                        try gop.value_ptr.put(arena, key, tn);
+                    }
+                }
+            }
+            // Recurse into generic args (they may themselves be
+            // cross-namespace closed generics).
+            for (tn.generics) |g| {
+                try collectCrossNsInstFromTy(out, arena, g, source_namespace);
+            }
+        },
+        .ptr_mut => |p| try collectCrossNsInstFromTy(out, arena, p.inner.*, source_namespace),
+        .ptr_const => |p| try collectCrossNsInstFromTy(out, arena, p.inner.*, source_namespace),
+        .ref_mut => |inner| try collectCrossNsInstFromTy(out, arena, inner.*, source_namespace),
+        .ref_const => |inner| try collectCrossNsInstFromTy(out, arena, inner.*, source_namespace),
+        .array => |inner| try collectCrossNsInstFromTy(out, arena, inner.*, source_namespace),
+        .array_fixed => |a| try collectCrossNsInstFromTy(out, arena, a.inner.*, source_namespace),
         else => {},
     }
 }
@@ -4944,4 +5056,57 @@ test "emitDef writes LIBRARY/EXPORTS with ordinal rewrite" {
         \\
     ;
     try std.testing.expectEqualStrings(expected, buf.written());
+}
+
+test "discoverCrossNsGenerics finds Calendar.Languages → IVectorView`1<HSTRING>" {
+    const bytes = @embedFile("Windows.winmd");
+    var file = try winmd.parse(bytes);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var pending: PendingGenericMap = .empty;
+    try discoverCrossNsGenerics(
+        &pending,
+        arena.allocator(),
+        &file,
+        "Windows.Globalization",
+    );
+
+    // Windows.Globalization.Calendar.Languages returns
+    // IVectorView`1<HSTRING>, whose open def lives in
+    // Windows.Foundation.Collections. Phase 4b discovery must route
+    // this into pending["Windows.Foundation.Collections"].
+    const collections_insts = pending.get("Windows.Foundation.Collections") orelse {
+        std.debug.print("expected pending entry for Windows.Foundation.Collections, got keys: ", .{});
+        for (pending.keys()) |k| std.debug.print("{s}, ", .{k});
+        std.debug.print("\n", .{});
+        return error.NoCollectionsSeed;
+    };
+
+    try std.testing.expect(collections_insts.contains("IVectorView__G1__HSTRING"));
+}
+
+test "discoverCrossNsGenerics ignores same-namespace closed generics" {
+    const bytes = @embedFile("Windows.winmd");
+    var file = try winmd.parse(bytes);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var pending: PendingGenericMap = .empty;
+    try discoverCrossNsGenerics(
+        &pending,
+        arena.allocator(),
+        &file,
+        "Windows.Foundation",
+    );
+
+    // The well-known TypedEventHandler`2<IMemoryBufferReference, object>
+    // instantiation is same-namespace (Windows.Foundation → Windows.Foundation),
+    // so it must NOT appear in the cross-ns pending map under
+    // "Windows.Foundation".
+    if (pending.get("Windows.Foundation")) |_| {
+        return error.SameNamespaceLeakedIntoPending;
+    }
 }

--- a/zig/packages/winbindgen/src/root.zig
+++ b/zig/packages/winbindgen/src/root.zig
@@ -1831,6 +1831,60 @@ fn collectCrossNsInstFromTy(
     }
 }
 
+/// Result of a bundle emission: one entry per input namespace mapping
+/// to the fully-emitted Zig source bytes (arena-allocated). The caller
+/// writes these out to disk / buffer.
+pub const BundleEmission = std.StringArrayHashMapUnmanaged([]const u8);
+
+/// Emit a bundle of namespaces as a single coordinated batch, auto-routing
+/// cross-namespace closed-generic instantiations to their home namespace.
+///
+/// Workflow:
+///   1. Pre-pass: for every input namespace, run `discoverCrossNsGenerics`
+///      to route closed generics to their home namespace's pending set.
+///   2. Fixpoint: re-run discovery until no new keys are added. Today a
+///      single pass suffices (discovery scans unsubstituted sigs, which
+///      is idempotent), but the loop guards against future substitution-
+///      based discovery. A `max_iters` cap prevents runaway loops.
+///   3. Emit: call `emitNamespaceEx` once per namespace, passing in its
+///      accumulated pending set as `extra_insts`.
+///
+/// The returned `BundleEmission` owns no memory beyond the arena; when
+/// the arena is freed all buffers vanish. The caller is expected to
+/// consume the bytes before arena teardown.
+pub fn emitBundle(
+    arena: std.mem.Allocator,
+    file: *const winmd.File,
+    namespaces: []const []const u8,
+    arch: Arch,
+) !BundleEmission {
+    var pending: PendingGenericMap = .empty;
+
+    const max_iters: usize = 4;
+    var iter: usize = 0;
+    while (iter < max_iters) : (iter += 1) {
+        var before: usize = 0;
+        for (pending.values()) |s| before += s.count();
+
+        for (namespaces) |ns| {
+            try discoverCrossNsGenerics(&pending, arena, file, ns);
+        }
+
+        var after: usize = 0;
+        for (pending.values()) |s| after += s.count();
+        if (after == before and iter > 0) break;
+    }
+
+    var out: BundleEmission = .empty;
+    for (namespaces) |ns| {
+        var buf: std.Io.Writer.Allocating = .init(arena);
+        const extra = pending.getPtr(ns);
+        try emitNamespaceEx(&buf.writer, arena, file, ns, arch, extra);
+        try out.put(arena, ns, buf.written());
+    }
+    return out;
+}
+
 /// Emit closed-generic instantiation structs for every entry in
 /// `insts`. For each mangled key the set stores the originating
 /// `winmd.TypeName` whose `.generics` slice carries the concrete args.
@@ -5109,4 +5163,40 @@ test "discoverCrossNsGenerics ignores same-namespace closed generics" {
     if (pending.get("Windows.Foundation")) |_| {
         return error.SameNamespaceLeakedIntoPending;
     }
+}
+
+test "emitBundle auto-routes IVectorView<HSTRING> to Foundation.Collections" {
+    const bytes = @embedFile("Windows.winmd");
+    var file = try winmd.parse(bytes);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const namespaces = [_][]const u8{
+        "Windows.Foundation",
+        "Windows.Foundation.Collections",
+        "Windows.Globalization",
+    };
+
+    var out = try emitBundle(arena.allocator(), &file, &namespaces, .x64);
+
+    // Every input namespace must produce an emission entry.
+    for (namespaces) |ns| {
+        try std.testing.expect(out.contains(ns));
+    }
+
+    // Foundation.Collections must carry the seeded IVectorView`1<HSTRING>
+    // closed-generic pair because Globalization's Calendar.Languages
+    // returns it.
+    const collections = out.get("Windows.Foundation.Collections").?;
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        collections,
+        "pub const IVectorView__G1__HSTRING = extern struct {",
+    ) != null);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        collections,
+        "pub const IVectorView__G1__HSTRING_Vtbl = extern struct {",
+    ) != null);
 }


### PR DESCRIPTION
Implements M4 Phase 4b: replaces the hand-coded undle_seeds table in `build.zig` with an auto-discovery driver that scans method signatures across namespaces and routes closed-generic instantiations to their home namespace for emission.

## Changes

- **Step 1** (`4d9777ef0`): `PendingGenericMap` + `discoverCrossNsGenerics` pre-pass in `root.zig`.
- **Step 2** (`13ab8d986`): Public `emitBundle` API + `BundleEmission` type with fixpoint loop (max 4 iters).
- **Step 3** (`0b5cd592b`): `winbindgen bundle` CLI subcommand writing one `<ns>.zig` per namespace to a `--outdir`.
- **Step 3.5** (`cf887a3bd`): Group bundle namespaces by winmd identity so Win32 + Wdk + WinRT can share one `bundle` invocation.
- **Step 4** (`8fb40ed41`): `build.zig` replaces the per-namespace `addRunArtifact` loop with a single `bundle` call plus `addOutputDirectoryArg`.
- **Step 5** (`546ce97e4`): Regenerated win-sys bindings (drift was pre-existing on `cataggar/zig`).

## Verification

Smoke test: `winbindgen bundle --outdir bundle-smoke Windows.Foundation Windows.Foundation.Collections Windows.Globalization` auto-routes `IVectorView\1<HSTRING>` (reached from Globalization via Foundation.Collections) into the Foundation.Collections bundle - the Calendar.Languages canary that motivated Phase 4b. The generated `Windows.Foundation.Collections.zig` contains `pub const IVectorView__G1__HSTRING_Vtbl`.

`zig build test` passes clean on base.

## Out of scope

- `writeZigTy` `allPrimitiveArgs` gate lifting for class/value args (deferred - not exercised by the current corpus).
- Parameterised IID (SHA-1) computation for cast/QI against closed generics.
- Generic delegates (`EventHandler\1`, `TypedEventHandler\2`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>