### PR TITLE
zig: unify cross-arch compile checks to use Phase 4b bundle driver

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1259,13 +1259,22 @@ pub fn build(b: *std.Build) void {
         cross_core_mod.linkSystemLibrary("api-ms-win-core-winrt-string-l1-1-0", .{});
         cross_core_mod.linkSystemLibrary("api-ms-win-core-winrt-l1-1-0", .{});
 
+        // M4 Phase 4b: use the `bundle` subcommand so cross-namespace
+        // closed-generic instantiations (e.g. `IVectorView``1<HSTRING>`
+        // reached from `Windows.Globalization`) are auto-routed into
+        // their home namespace under every target arch, mirroring the
+        // host-Windows `compile-check-bundle` above.
+        const cross_bundle_run = b.addRunArtifact(winbindgen_exe);
+        cross_bundle_run.addArg("bundle");
+        cross_bundle_run.addArg(ca.flag);
+        cross_bundle_run.addArg("--outdir");
+        const cross_bundle_outdir = cross_bundle_run.addOutputDirectoryArg("bundle");
+        for (bundle_namespaces) |ns| cross_bundle_run.addArg(ns);
+
         const cross_wf = b.addWriteFiles();
         for (bundle_namespaces) |ns| {
-            const gen_run = b.addRunArtifact(winbindgen_exe);
-            gen_run.addArg(ca.flag);
-            gen_run.addArg(ns);
-            const gen_source = gen_run.captureStdOut(.{});
-            _ = cross_wf.addCopyFile(gen_source, b.fmt("{s}.zig", .{ns}));
+            const src = cross_bundle_outdir.path(b, b.fmt("{s}.zig", .{ns}));
+            _ = cross_wf.addCopyFile(src, b.fmt("{s}.zig", .{ns}));
         }
         const cross_root = cross_wf.getDirectory().path(b, b.fmt("{s}.zig", .{bundle_namespaces[0]}));
 


### PR DESCRIPTION
Unify the four compile-check variants in `zig/build.zig` so all of them exercise the Phase 4b `bundle` driver and its cross-namespace closed-generic auto-routing.

## Before

- Host Windows: `winbindgen bundle --outdir ...` (Phase 4b driver, auto-routes `IVectorView\1<HSTRING>` from `Windows.Globalization` into `Windows.Foundation.Collections`).
- Cross x86 / x64 / arm64: per-namespace `winbindgen <arch-flag> <ns>` loop (pre-Phase-4b, no cross-ns routing, falls back to `*anyopaque` for cross-ns closed generics).

## After

All four paths call `winbindgen bundle <arch-flag> --outdir <bundle> <ns...>` and compile-check the same typed surface.

## Why

The divergence meant that the cross-arch CI jobs silently accepted a strictly weaker projection than the host path. After this change, a regression in cross-namespace closed-generic routing surfaces on every target triple we test, not just x86_64-msvc.

No new tests needed: the unit tests for `discoverCrossNsGenerics` and `emitBundle` in `root.zig` already pin the auto-routing behaviour; this PR just makes three additional CI jobs actually exercise it.

---
<sub>Session ID for resuming locally: `ebe79a20-0c18-44c9-8c94-f77d36816d32`</sub>
