### PR TITLE
zig: M6 - emit Class.factory() and Class.statics[N]() helpers

### DIFF
--- a/zig/docs/winrt-v02-scope.md
+++ b/zig/docs/winrt-v02-scope.md
@@ -281,13 +281,55 @@ cross-namespace closed generics; host-Windows and cross-arch
     interface settles.
 - One sample per pattern that survives the design pass.
 
-### M6 — Comptime WinRT
+### M6 — WinRT activation ergonomics (landed)
 
-- Extend `project()` to accept WinRT interfaces and runtime classes.
-- Gated by an explicit `.winrt = true` config so Win32-only callers
-  pay nothing.
-- Sample: `project({ .@"Windows.Globalization" = .{"Calendar"} })`
-  with a size benchmark.
+Shipped in #TBD (cataggar/zig-m6-factory-methods).
+
+Original scope (from v0.2 draft): "Extend `project()` to accept WinRT
+interfaces and runtime classes, gated by `.winrt = true`."
+
+Reality after probing the codegen shape: WinRT bundles are emitted
+wholesale and Zig's DCE already removes unused paths, so a
+`project()`-style filter has no credible size story. The shipping
+gap was ergonomic — every call site paid
+`core.activationFactory(Class.Factory.Vtbl, &Class.Factory.IID, &Class.NAME_W)`
+(three tokens for one intent) before reaching the typed factory. The
+pivot (after rubber-duck critique) was to emit the sugar on the class
+struct itself:
+
+```zig
+pub const Uri = extern struct {
+    vtable: *const IUriRuntimeClass_Vtbl,
+    pub const NAME_W: [22]u16 = .{ ... };
+    pub const Factory = IUriRuntimeClassFactory;
+    pub const Statics = IUriEscapeStatics;
+
+    pub fn factory() !win_core.Com(Factory.Vtbl) {
+        return win_core.activationFactory(Factory.Vtbl, &Factory.IID, &NAME_W);
+    }
+    pub fn statics() !win_core.Com(Statics.Vtbl) {
+        return win_core.activationFactory(Statics.Vtbl, &Statics.IID, &NAME_W);
+    }
+};
+```
+
+Emitted by `emitRuntimeClasses` alongside the existing `activate()`
+for parameterless-activatable classes. Classes carrying
+`Statics2`/`Statics3` sibling aliases get matching `statics2()` /
+`statics3()` methods numbered to match. Gating piggy-backs on the
+alias emission: no `Factory` alias → no `factory()` method.
+
+Samples updated:
+
+- `samples/winrt_uri`: `core.activationFactory(Uri.Factory.Vtbl, ...)`
+  → `try Uri.factory()`.
+- `samples/winrt_calendar`: same collapse for
+  `ApplicationLanguages.statics()`.
+
+Size story is explicitly DCE-driven: classes whose `factory()` /
+`statics()` are never referenced don't get emitted into the final
+binary, same as any other unused `pub fn` in a Zig library. See
+`docs/comptime-vs-codegen.md` for the full cap discussion.
 
 ## Non-goals for v0.2
 
@@ -322,8 +364,9 @@ cross-namespace closed generics; host-Windows and cross-arch
   full `HSTRING` round-trip. — `winrt_uri` and `winrt_calendar` both
   run in `samples` step; `winrt_calendar` additionally drives a
   cross-namespace closed-generic `IVectorView<HSTRING>`.
-- [ ] A `project()` example pulls in a WinRT runtime class and calls
-  a method, under a gated config. — **M6.**
+- [x] WinRT activation ergonomics: emitted `Class.factory()` /
+  `Class.statics[N]()` methods replace the
+  `activationFactory(Vtbl, &IID, &NAME_W)` triple at call sites. — **M6.**
 - [ ] `docs/comptime-vs-codegen.md` updated with the WinRT cap
-  numbers. — **pending M6.**
+  numbers. — **pending M6 follow-up.**
 - [ ] This file is rewritten as a changelog, not a plan.

--- a/zig/packages/winbindgen/src/root.zig
+++ b/zig/packages/winbindgen/src/root.zig
@@ -3831,7 +3831,15 @@ fn writeFactoryAlias(
     } else if (isProjectableNs(factory.namespace)) {
         try cross.put(arena, factory.namespace, {});
         try writer.print("    pub const Factory = @\"{s}\".{s};\n", .{ factory.namespace, factory.name });
+    } else {
+        return;
     }
+    try writer.writeAll(
+        \\    pub fn factory() !win_core.Com(Factory.Vtbl) {
+        \\        return win_core.activationFactory(Factory.Vtbl, &Factory.IID, &NAME_W);
+        \\    }
+        \\
+    );
 }
 
 /// Scan the custom attributes on runtime-class row `class_row` for
@@ -3967,6 +3975,21 @@ fn writeStaticsAliases(
             } else {
                 try writer.print("    pub const Statics{d} = @\"{s}\".{s};\n", .{ index, statics.namespace, statics.name });
             }
+        }
+        if (index == 1) {
+            try writer.writeAll(
+                \\    pub fn statics() !win_core.Com(Statics.Vtbl) {
+                \\        return win_core.activationFactory(Statics.Vtbl, &Statics.IID, &NAME_W);
+                \\    }
+                \\
+            );
+        } else {
+            try writer.print(
+                "    pub fn statics{d}() !win_core.Com(Statics{d}.Vtbl) {{\n" ++
+                    "        return win_core.activationFactory(Statics{d}.Vtbl, &Statics{d}.IID, &NAME_W);\n" ++
+                    "    }}\n",
+                .{ index, index, index, index },
+            );
         }
     }
 }

--- a/zig/samples/winrt_calendar/main.zig
+++ b/zig/samples/winrt_calendar/main.zig
@@ -41,13 +41,10 @@ pub fn main(init: std.process.Init) !void {
 
     // `ApplicationLanguages` is a pure-static WinRT class: no instance
     // activation, just an `IActivationFactory` that also implements
-    // `IApplicationLanguagesStatics`. `ApplicationLanguages.Statics`
-    // is the emitter-generated alias for that statics interface.
-    const factory = try core.activationFactory(
-        ApplicationLanguages.Statics.Vtbl,
-        &ApplicationLanguages.Statics.IID,
-        &ApplicationLanguages.NAME_W,
-    );
+    // `IApplicationLanguagesStatics`. `ApplicationLanguages.statics()`
+    // is the M6 convenience wrapper around `activationFactory` keyed
+    // off the `Statics` alias.
+    const factory = try ApplicationLanguages.statics();
     defer factory.deinit();
 
     const statics_this: *const ApplicationLanguages.Statics =

--- a/zig/samples/winrt_uri/main.zig
+++ b/zig/samples/winrt_uri/main.zig
@@ -33,11 +33,10 @@ pub fn main(init: std.process.Init) !void {
     // Activation factory for `Windows.Foundation.Uri`, typed as
     // `IUriRuntimeClassFactory` via `Uri.Factory` (emitter-generated
     // from `[Activatable(typeof(IUriRuntimeClassFactory), ...)]`).
-    const factory = try core.activationFactory(
-        Uri.Factory.Vtbl,
-        &Uri.Factory.IID,
-        &Uri.NAME_W,
-    );
+    // `Uri.factory()` is the M6 convenience that collapses
+    // `core.activationFactory(Uri.Factory.Vtbl, &Uri.Factory.IID, &Uri.NAME_W)`
+    // down to a single call.
+    const factory = try Uri.factory();
     defer factory.deinit();
 
     // Construct the Uri instance. `CreateUriFromUtf16` is the M2


### PR DESCRIPTION
## M6 — WinRT activation ergonomics

Original scope was to extend `project()` to accept WinRT runtime classes under a `.winrt = true` config. After probing the codegen shape, the rubber-duck pass was blunt: the filter had no size story. WinRT bundles are emitted wholesale and Zig''s DCE already removes unused paths, so a `project()`-style filter would be pure ceremony. The real ergonomic gap was the three-token

```zig
core.activationFactory(Class.Factory.Vtbl, &Class.Factory.IID, &Class.NAME_W)
```

at every activation site.

### Pivot

Emit the sugar on the class struct itself, next to the existing `activate()` method on parameterless-activatable classes:

```zig
pub const Uri = extern struct {
    vtable: *const IUriRuntimeClass_Vtbl,
    pub const NAME_W: [22]u16 = .{ ... };
    pub const Factory = IUriRuntimeClassFactory;
    pub const Statics = IUriEscapeStatics;

    pub fn factory() !win_core.Com(Factory.Vtbl) {
        return win_core.activationFactory(Factory.Vtbl, &Factory.IID, &NAME_W);
    }
    pub fn statics() !win_core.Com(Statics.Vtbl) {
        return win_core.activationFactory(Statics.Vtbl, &Statics.IID, &NAME_W);
    }
};
```

- `factory()` is emitted when the class has a typed `[Activatable(typeof(IFooFactory), ...)]`.
- `statics()` / `statics2()` / `statics3()` are emitted per `[Static(typeof(IFooStatics[N]), ...)]`, matching the existing `Statics[N]` alias numbering (e.g. `CalendarIdentifiers.Statics2` → `statics2()`).
- Both work cross-namespace because the alias already carries the qualified type; the method body references `Factory` / `Statics` transparently.
- Gating is evidence-driven: no alias → no method. Calling a non-existent method yields a normal Zig "no field named" error at the call site — same diagnostic path the scope doc called out as important.

### Sample diff

```diff
-const factory = try core.activationFactory(
-    Uri.Factory.Vtbl, &Uri.Factory.IID, &Uri.NAME_W,
-);
+const factory = try Uri.factory();
```

- `samples/winrt_uri` (typed-factory activation) — collapses to `try Uri.factory()`.
- `samples/winrt_calendar` (pure-static class) — collapses to `try ApplicationLanguages.statics()`.

Both samples run end-to-end locally.

### Tests

- `zig build test` — passes.
- `zig build samples` — passes.
- `zig build run-winrt-uri` / `run-winrt-calendar` — both produce the expected output.

### Docs

- `zig/docs/winrt-v02-scope.md` M6 section rewritten from the `project()` filter draft to the emitted-method reality, with the DCE rationale. Definition-of-done checkbox flipped.

### Size story

Explicitly DCE-driven, not filter-driven: `factory()` / `statics()` methods are `pub fn` on generic structs, so unused ones are eliminated by Zig''s normal reachability analysis the same as any unused library function. Documented in the scope doc.

### Non-goals (still deferred)

- Parameterised-IID for closed generics (SHA-1). `cast()` / QI onto closed generics stays unsupported.
- Generic delegates (`EventHandler``1`, `TypedEventHandler``2`).
- Async contracts (M5).

---
<sub>Session ID for resuming locally: `ebe79a20-0c18-44c9-8c94-f77d36816d32`</sub>
