### PR TITLE
zig: #3 Phase A+B — PassArray and array returns

### DIFF
--- a/zig/packages/winbindgen/src/root.zig
+++ b/zig/packages/winbindgen/src/root.zig
@@ -2213,29 +2213,53 @@ fn writeMethodWrapper(
     const sig = winmd.readMethodSignature(arena, file, sig_blob) catch return;
 
     if (!canRepresent(sig.return_type)) return;
-    for (sig.params) |p| {
+    for (sig.params, 0..) |p, i| {
         if (!canRepresent(p)) return;
+        if (!isPhaseBArrayOk(p, file, method_row, @intCast(i))) return;
     }
 
     try writer.print("    pub fn {s}(self: *const {s}", .{ method_name, this_name });
     for (sig.params, 0..) |p, i| {
-        try writer.print(", p{d}: ", .{i});
-        try writeParam(writer, arena, p, current_namespace, cross);
+        switch (p) {
+            .array => |inner| {
+                try writer.print(", p{d}_size: u32, p{d}_ptr: [*]const ", .{ i, i });
+                _ = try writeZigTy(writer, arena, inner.*, current_namespace, cross, null, null, null);
+            },
+            else => {
+                try writer.print(", p{d}: ", .{i});
+                try writeParam(writer, arena, p, current_namespace, cross);
+            },
+        }
     }
     // Classic-COM methods already return HRESULT directly; only
     // synthesize the WinRT-style `result: *T` out-param when the
-    // logical return is a non-HRESULT / non-void value.
+    // logical return is a non-HRESULT / non-void value. Array returns
+    // always split into a `result_size: *u32, result_ptr: *[*]T` pair.
     const split_return = sig.return_type != .void and !isHresultTy(sig.return_type);
     if (split_return) {
-        try writer.writeAll(", result: *");
-        _ = try writeZigTy(writer, arena, sig.return_type, current_namespace, cross, null, null, null);
+        switch (sig.return_type) {
+            .array => |inner| {
+                try writer.writeAll(", result_size: *u32, result_ptr: *[*]");
+                _ = try writeZigTy(writer, arena, inner.*, current_namespace, cross, null, null, null);
+            },
+            else => {
+                try writer.writeAll(", result: *");
+                _ = try writeZigTy(writer, arena, sig.return_type, current_namespace, cross, null, null, null);
+            },
+        }
     }
     try writer.print(") callconv(.winapi) HRESULT {{\n        return self.vtable.@\"{s}\"(self", .{vtbl_field_name});
-    for (sig.params, 0..) |_, i| {
-        try writer.print(", p{d}", .{i});
+    for (sig.params, 0..) |p, i| {
+        switch (p) {
+            .array => try writer.print(", p{d}_size, p{d}_ptr", .{ i, i }),
+            else => try writer.print(", p{d}", .{i}),
+        }
     }
     if (split_return) {
-        try writer.writeAll(", result");
+        switch (sig.return_type) {
+            .array => try writer.writeAll(", result_size, result_ptr"),
+            else => try writer.writeAll(", result"),
+        }
     }
     try writer.writeAll(");\n    }\n");
 
@@ -2246,14 +2270,17 @@ fn writeMethodWrapper(
     // if `Hstring.create` fails. Uses `[]const u16` (not `[]const u8`)
     // to avoid requiring an allocator — callers feed `win_core.utf16Lit`
     // literals or the slice from an already-created wide string.
+    //
+    // Skip the sugar when any sig param is an array — Phase B keeps
+    // the raw ABI shape only; mixing HSTRING sugar with split-pair
+    // array params is a follow-up.
     var has_hstring_in = false;
+    var has_array_param = false;
     for (sig.params) |p| {
-        if (p == .string) {
-            has_hstring_in = true;
-            break;
-        }
+        if (p == .string) has_hstring_in = true;
+        if (p == .array) has_array_param = true;
     }
-    if (has_hstring_in) {
+    if (has_hstring_in and !has_array_param and sig.return_type != .array) {
         try writer.print("    pub fn {s}FromUtf16(self: *const {s}", .{ method_name, this_name });
         for (sig.params, 0..) |p, i| {
             try writer.print(", p{d}: ", .{i});
@@ -2349,8 +2376,15 @@ fn writeMethodPointer(
         try writer.writeAll("*const anyopaque");
         return;
     }
-    for (sig.params) |p| {
+    for (sig.params, 0..) |p, i| {
         if (!canRepresent(p)) {
+            try writer.writeAll("*const anyopaque");
+            return;
+        }
+        // Phase B covers only IN arrays (PassArray). FillArray /
+        // ReceiveArray arrays (OUT, and `ref_mut(.array)`) are deferred
+        // to Phase C — fall back to opaque until then.
+        if (!isPhaseBArrayOk(p, file, method_row, @intCast(i))) {
             try writer.writeAll("*const anyopaque");
             return;
         }
@@ -2358,15 +2392,33 @@ fn writeMethodPointer(
 
     try writer.print("*const fn (this: *const {s}", .{this_name});
     for (sig.params, 0..) |p, i| {
-        try writer.print(", p{d}: ", .{i});
-        try writeParam(writer, arena, p, current_namespace, cross);
+        switch (p) {
+            .array => |inner| {
+                try writer.print(", p{d}_size: u32, p{d}_ptr: [*]const ", .{ i, i });
+                _ = try writeZigTy(writer, arena, inner.*, current_namespace, cross, null, null, null);
+            },
+            else => {
+                try writer.print(", p{d}: ", .{i});
+                try writeParam(writer, arena, p, current_namespace, cross);
+            },
+        }
     }
     // Mirrors the split-return gate in `writeMethodWrapper`. Classic
     // COM: return HRESULT directly. WinRT: logical return becomes a
     // trailing `result: *T` out-param and the function returns HRESULT.
+    // Array returns are always callee-allocated — they split into a
+    // trailing `result_size: *u32, result_ptr: *[*]T` pair.
     if (sig.return_type != .void and !isHresultTy(sig.return_type)) {
-        try writer.writeAll(", result: *");
-        _ = try writeZigTy(writer, arena, sig.return_type, current_namespace, cross, null, null, null);
+        switch (sig.return_type) {
+            .array => |inner| {
+                try writer.writeAll(", result_size: *u32, result_ptr: *[*]");
+                _ = try writeZigTy(writer, arena, inner.*, current_namespace, cross, null, null, null);
+            },
+            else => {
+                try writer.writeAll(", result: *");
+                _ = try writeZigTy(writer, arena, sig.return_type, current_namespace, cross, null, null, null);
+            },
+        }
     }
     try writer.writeAll(") callconv(.winapi) HRESULT");
 }
@@ -2423,8 +2475,40 @@ fn canRepresent(ty: winmd.Ty) bool {
         .ptr_mut => |p| canRepresent(p.inner.*),
         .ptr_const => |p| canRepresent(p.inner.*),
         .array_fixed => |a| canRepresent(a.inner.*),
+        // SZARRAY: representable only when the element type is
+        // representable. Direction (IN vs OUT) is enforced separately
+        // by `isPhaseBArrayOk` at each emit site — Phase B only emits
+        // IN arrays, Phase C will extend to OUT.
+        .array => |inner| canRepresent(inner.*),
         else => false,
     };
+}
+
+/// Phase B array gate. Returns `false` for sig params that carry a
+/// SZARRAY shape we don't yet emit (OUT arrays — FillArray /
+/// ReceiveArray). Non-array params always pass.
+///
+/// ECMA-335 Param flags expose the direction:
+///   - `[in]`  only  → PassArray (caller-owned input buffer)
+///   - `[out]` only  → FillArray (caller-allocated output buffer)
+///   - both    → ReceiveArray (callee-allocated output — rendered on
+///                              the `ref_mut(.array)` shape)
+///
+/// Phase B accepts IN-only arrays. Everything else falls back to
+/// `*const anyopaque` at the call site until Phase C lands.
+fn isPhaseBArrayOk(p: winmd.Ty, file: *const winmd.File, method_row: u32, sig_index: u32) bool {
+    switch (p) {
+        .array => {
+            const flags = file.paramFlags(method_row, sig_index);
+            return flags.in and !flags.out;
+        },
+        .ref_mut => |inner| {
+            // `ref_mut(.array)` is always ReceiveArray (OUT) — defer
+            // to Phase C.
+            return inner.* != .array;
+        },
+        else => return true,
+    }
 }
 
 /// Returns true iff `arg` is a generic-type argument we can mangle
@@ -2863,6 +2947,17 @@ test "emitInterfaceVtbls writes IStringable_Vtbl with ToString slot" {
         u8,
         out,
         "CreateInt32: *const fn (this: *const IPropertyValueStatics, p0: i32, result: *?*const anyopaque) callconv(.winapi) HRESULT",
+    ) != null);
+
+    // Phase B (issue #3): SZARRAY inputs with `[in]` (PassArray) lower
+    // to a two-slot vtbl pair `p{N}_size: u32, p{N}_ptr: [*]const T`.
+    // `CreateInt32Array([in] UINT32 __valueSize, [in] INT32[] value)
+    // → IInspectable** propertyValue` exercises the primitive case.
+    // Previously the whole slot fell back to `*const anyopaque`.
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        out,
+        "CreateInt32Array: *const fn (this: *const IPropertyValueStatics, p0_size: u32, p0_ptr: [*]const i32, result: *?*const anyopaque) callconv(.winapi) HRESULT",
     ) != null);
 
     // At least one interface in Windows.Foundation uses types we don't

--- a/zig/packages/winmd/src/root.zig
+++ b/zig/packages/winmd/src/root.zig
@@ -236,6 +236,47 @@ pub const File = struct {
     pub fn implMapImportName(self: *const File, impl_map_row: u32) []const u8 {
         return self.str(.impl_map, impl_map_row, 2);
     }
+
+    /// ParamAttributes for the Param row that describes signature parameter
+    /// `sig_index` (0-based) of MethodDef row `method_row`. Sequence 0 in
+    /// the Param table is the return value; `sig_index == 0` addresses the
+    /// first regular parameter and matches Sequence == 1.
+    ///
+    /// Param rows are optional (ECMA-335 §II.22.33): an all-zero
+    /// `ParamFlags` means either "no row at all" or "row exists with no
+    /// flags set". For the WinRT array-direction decision both cases
+    /// mean the same thing — treat as neither IN nor OUT.
+    pub fn paramFlags(self: *const File, method_row: u32, sig_index: u32) ParamFlags {
+        const range = self.list(.method_def, method_row, 5, .method_param);
+        const target_seq: u32 = sig_index + 1;
+        var i = range.start;
+        while (i < range.end) : (i += 1) {
+            const seq = self.cell(.method_param, i, 1);
+            if (seq == target_seq) {
+                const bits: u16 = @intCast(self.cell(.method_param, i, 0));
+                return @bitCast(bits);
+            }
+            if (seq > target_seq) break;
+        }
+        return @bitCast(@as(u16, 0));
+    }
+};
+
+/// ECMA-335 §II.23.1.13 ParamAttributes. Only the bits we decode are
+/// named; the rest are reserved and preserved as padding so the struct
+/// round-trips a raw u16.
+pub const ParamFlags = packed struct(u16) {
+    /// `[in]` — parameter is read by the callee.
+    in: bool,
+    /// `[out]` — parameter is written by the callee.
+    out: bool,
+    _pad_2_3: u2,
+    /// `[optional]` — caller may pass a default-valued argument.
+    optional: bool,
+    _pad_5_11: u7,
+    has_default: bool,
+    has_field_marshal: bool,
+    _pad_14_15: u2,
 };
 
 fn lowerBound(f: *const File, table: Table, first_in: u32, last: u32, column: u3, value: u32) u32 {
@@ -1892,6 +1933,58 @@ test "method signature decodes IClosable.Close as void()" {
 
     // Malformed blob: claims 1 param but has no type byte after void return.
     try std.testing.expectError(error.ShortBlob, readMethodSignature(arena.allocator(), &f, &[_]u8{ 0x20, 0x01, 0x01 }));
+}
+
+test "paramFlags decodes WinRT array directions (IN for PassArray, OUT for FillArray)" {
+    const bytes = @embedFile("Windows.winmd");
+    const f = try parse(bytes);
+
+    var index = try TypeIndex.init(std.testing.allocator, &f);
+    defer index.deinit();
+
+    // Helper: locate method `name` inside TypeDef `type_row`.
+    const H = struct {
+        fn find(file: *const File, type_row: u32, name: []const u8) ?u32 {
+            const methods = file.list(.type_def, type_row, 5, .method_def);
+            var i = methods.start;
+            while (i < methods.end) : (i += 1) {
+                if (std.mem.eql(u8, file.str(.method_def, i, 3), name)) return i;
+            }
+            return null;
+        }
+    };
+
+    // --- PassArray: IPropertyValueStatics.CreateInt32Array(value) is [in].
+    const pvs_rows = index.get("Windows.Foundation", "IPropertyValueStatics");
+    try std.testing.expectEqual(@as(usize, 1), pvs_rows.len);
+    const create_row = H.find(&f, pvs_rows[0], "CreateInt32Array") orelse return error.MissingMethod;
+
+    // Sig param 0 is the array (`value`); the [out, retval] return is
+    // the HRESULT + IPropertyValue** split, not a sig param.
+    const in_flags = f.paramFlags(create_row, 0);
+    try std.testing.expect(in_flags.in);
+    try std.testing.expect(!in_flags.out);
+
+    // --- FillArray: IVector`1.GetMany(startIndex, [out] items).
+    // TypeIndex strips the arity suffix; pick the arity-1 row by raw name.
+    const ivec_rows = index.get("Windows.Foundation.Collections", "IVector");
+    var ivec_row: ?u32 = null;
+    for (ivec_rows) |r| {
+        if (std.mem.eql(u8, f.str(.type_def, r, 1), "IVector`1")) {
+            ivec_row = r;
+            break;
+        }
+    }
+    try std.testing.expect(ivec_row != null);
+    const get_many_row = H.find(&f, ivec_row.?, "GetMany") orelse return error.MissingMethod;
+
+    // Param 0 = startIndex (UInt32, [in]); param 1 = items (T[], [out]).
+    const p0 = f.paramFlags(get_many_row, 0);
+    try std.testing.expect(p0.in);
+    try std.testing.expect(!p0.out);
+    const p1 = f.paramFlags(get_many_row, 1);
+    try std.testing.expect(p1.out);
+    try std.testing.expect(!p1.in);
 }
 
 test "attribute helpers find Point's ContractVersionAttribute" {


### PR DESCRIPTION
Closes #3 Phase A+B.

**Phase A — Param flags reader** (packages/winmd)
- Public paramFlags(method_row, sig_index) ParamFlags on File; reads Param table IN/OUT/OPTIONAL bits matching Rust's Param::is_input / is_output.

**Phase B — PassArray + array returns**
- `canRepresent` accepts `.array(T)` when `canRepresent(T)`.
- `writeMethodPointer` / `writeMethodWrapper` emit split-pair `p{i}_size: u32, p{i}_ptr: [*]const T` for `[in]` array params.
- Array returns emit trailing `result_size: *u32, result_ptr: *[*]T` pair.
- FromUtf16 / Owned HSTRING sugar suppressed on methods with array params/returns (arrays forward raw).
- Phase C territory (`[out]` FillArray + `ref_mut` ReceiveArray) still falls back to opaque — lands in chained PR.

**Verification**
All 19 `IPropertyValueStatics.Create*Array` slots (u8, i16, u16, i32, u32, i64, u64, f32, f64, Char16, BOOL, HSTRING, Object, GUID, DateTime, TimeSpan, Point, Size, Rect) render typed. Zero opaque fallback on the Phase B corpus.

`zig build test --summary all` → 95/97 (2 pre-existing skips).