### PR TITLE
zig: M2 — IVector<HSTRING> golden vector for parameterizedIid (#13)

### DIFF
--- a/zig/packages/winbindgen/src/root.zig
+++ b/zig/packages/winbindgen/src/root.zig
@@ -2216,6 +2216,25 @@ test "parameterizedIid matches IReference<bool> golden vector" {
     try std.testing.expectEqual(expected, got);
 }
 
+test "parameterizedIid matches IVector<HSTRING> golden vector" {
+    // Second independent vector: `IVector<HSTRING>`. The open-template
+    // IID `913337e9-11a1-4345-a3a2-4e7f956e222d` is the IVector<T>
+    // GuidAttribute used across `windows-rs`; the closed IID was
+    // computed from that signature by the reference SHA-1 + bit-flip
+    // recipe (`crates/libs/core/src/guid.rs::GUID::from_signature`).
+    const sig = "pinterface({913337e9-11a1-4345-a3a2-4e7f956e222d};string)";
+    const got = parameterizedIid(sig);
+
+    const expected: GUID_t = .{
+        .data1 = 0x98b9acc1,
+        .data2 = 0x4b56,
+        .data3 = 0x532e,
+        .data4 = .{ 0xac, 0x73, 0x03, 0xd5, 0x29, 0x1c, 0xca, 0x90 },
+    };
+
+    try std.testing.expectEqual(expected, got);
+}
+
 /// Read a TypeDef's `GuidAttribute` and return the assembled GUID, or
 /// null if the type carries no `GuidAttribute` or the attribute payload
 /// has the wrong shape. Same parser as `writeInterfaceIid` — kept


### PR DESCRIPTION
Issue #13, milestone M2. Adds a second independent golden vector for the SHA-1-based parameterized-IID helper landed in M0/M1.

- `IReference<bool>` -> `{3c00fd60-2950-5939-a21a-2d12c5a01b8a}` (M0, already in tree)
- `IVector<HSTRING>` -> `{98b9acc1-4b56-532e-ac73-03d5291cca90}` (this PR)

Two vectors with disjoint sig shapes (`b1` vs `string`) is enough to nail down endianness, namespace bytes, and the v5 bit-flip in one place. The expected IID was computed independently with Python's `hashlib.sha1` against the WinRT PIID namespace `11f47ad57b7342c0abae878b1e16adee` and matches what `parameterizedIid` produces.

Out of scope: emitter wire-in (M3).