### PR TITLE
Issue #13 M3: emit parameterized IID on closed WinRT generics

### DIFF
--- a/zig/packages/winbindgen/src/root.zig
+++ b/zig/packages/winbindgen/src/root.zig
@@ -1952,9 +1952,36 @@ fn emitGenericInstantiations(
                 \\pub const {s} = extern struct {{
                 \\    vtable: *const {s}_Vtbl,
                 \\    pub const Vtbl = {s}_Vtbl;
-                \\}};
                 \\
             , .{ mangled_name, mangled_name, mangled_name });
+
+            // Emit the parameterised IID for this closed instantiation.
+            // Best-effort: if the open def lacks a `GuidAttribute` or
+            // an arg type uses a sig variant we don't yet handle, skip
+            // the IID so the rest of the handle still compiles. Callers
+            // that need it will get a clear "no field IID" error from
+            // `cast()` rather than wrong bytes.
+            emit_iid: {
+                const ty: winmd.Ty = .{ .class_name = .{
+                    .namespace = tn.namespace,
+                    .name = tn.name,
+                    .generics = tn.generics,
+                } };
+                var sig_buf: std.Io.Writer.Allocating = .init(arena);
+                writeRuntimeSignature(&sig_buf.writer, arena, file, ty) catch break :emit_iid;
+                const iid = parameterizedIid(sig_buf.written());
+                try writer.print(
+                    "    pub const IID: GUID = .{{ .data1 = 0x{x:0>8}, .data2 = 0x{x:0>4}, .data3 = 0x{x:0>4}, .data4 = .{{ 0x{x:0>2}, 0x{x:0>2}, 0x{x:0>2}, 0x{x:0>2}, 0x{x:0>2}, 0x{x:0>2}, 0x{x:0>2}, 0x{x:0>2} }} }};\n",
+                    .{
+                        iid.data1,    iid.data2,    iid.data3,
+                        iid.data4[0], iid.data4[1], iid.data4[2],
+                        iid.data4[3], iid.data4[4], iid.data4[5],
+                        iid.data4[6], iid.data4[7],
+                    },
+                );
+            }
+
+            try writer.writeAll("};\n");
         }
 
         // Remove processed entries. If the worklist grew during


### PR DESCRIPTION
Wires the M2 `parameterizedIid` recipe into `emitGenericInstantiations` so every closed WinRT generic handle struct now carries a `pub const IID: GUID`.

Implementation:
- After emitting the handle struct's `vtable` field and `Vtbl` alias, build the runtime-type signature for the closed instantiation via the existing `writeRuntimeSignature` and feed it through `parameterizedIid`.
- Best-effort emit: if the open def has no `GuidAttribute` or any participating type uses an unsupported sig variant, we `break :emit_iid` and skip the IID rather than fail the build. This matches the non-generic `writeInterfaceIid` tolerance.

End-to-end validation (from a fresh `zig build`):
- `IVector__G1__HSTRING` -> `{98b9acc1-4b56-532e-ac73-03d5291cca90}` (matches the M2 golden vector exactly)
- `IVectorView__G1__Windows_Foundation_Uri` -> `{4b8385bd-a2cd-5ff1-bf74-7ea580423e50}` (correct v5 `5xxx` data3)

Tests: `zig build test` green; existing `parameterizedIid` golden tests for `IReference<bool>` and `IVector<HSTRING>` continue to pass.

Refs #13 (M3). Next is M4 (smoke + sample exercising `cast()` across a closed generic).