### PR TITLE
zig: M0 for issue #14 - delegate vtbl ABI fix + design doc

### DIFF
--- a/zig/docs/generic-delegates.md
+++ b/zig/docs/generic-delegates.md
@@ -1,0 +1,174 @@
+# Generic delegates and add/remove-handler sugar
+
+WinRT's event model is built on **delegates** — small COM-callable
+function objects that the runtime invokes when an event fires. The two
+canonical generic delegates are:
+
+- `Windows.Foundation.EventHandler<T>` — `Invoke(sender: object, args: T)`
+- `Windows.Foundation.TypedEventHandler<TSender, TArgs>` —
+  `Invoke(sender: TSender, args: TArgs)`
+
+Plus a long tail of one-off generic delegates (`AsyncOperationCompletedHandler<T>`,
+`AsyncOperationProgressHandler<T,P>`, etc.) used by the async contracts.
+
+After issue #13 the Zig emitter reaches **closed-generic instantiations**
+of these delegates: for each `(TypedEventHandler, T, U)` referenced by
+the corpus we emit a typed handle struct, a typed `_Vtbl` with the
+`Invoke` slot, and a parameterised IID constant.
+
+Issue #14 lands the runtime + codegen pieces that make these instantiations
+actually **usable** from Zig — so a caller can register a handler on a
+WinRT event source, hold the registration token, and unregister it
+later.
+
+## ABI in one page
+
+A WinRT delegate is a COM object whose vtable is `IUnknown` plus a
+single `Invoke` slot. Specifically:
+
+| Slot | Method                                | Notes |
+|------|---------------------------------------|-------|
+| 0    | `QueryInterface(riid, ppv)`           | Must succeed for `IID_IUnknown`, the delegate's own IID, and `IID_IAgileObject` (marker, returns `self`). |
+| 1    | `AddRef()`                            | Increments the strong count. |
+| 2    | `Release()`                           | Decrements; frees on zero. |
+| 3    | `Invoke(arg0, arg1, ...)`             | Signature matches the delegate's `Invoke` method in winmd. Returns `HRESULT`. |
+
+The thing that trips up every fresh implementation: WinRT delegates
+**do not extend `IInspectable`**. In winmd they are
+`extends System.MulticastDelegate`, which the runtime treats as a sibling
+of `Object`, not a subclass. So the vtable layout is `IUnknown_Vtbl + Invoke`
+(4 slots), **not** `IInspectable_Vtbl + Invoke` (7 slots). Confusing,
+because every other WinRT type does extend `IInspectable`.
+
+The Zig emitter's closed-generic instantiation path now reflects this:
+when the closed type's open template has `extends MulticastDelegate`,
+the emitted `_Vtbl` uses `base: IUnknown_Vtbl`. Otherwise (true WinRT
+interface) it uses `base: IInspectable_Vtbl`. See the regression test
+`"closed-generic delegate vtbl uses IUnknown_Vtbl base, not
+IInspectable_Vtbl"` in `winbindgen` and the matching code in
+`emitGenericInstantiations`. Without this fix the emitted `Invoke`
+slot would be three vtbl entries too late and any call would dispatch
+into garbage; the M0 fix is the correctness foundation that M1's
+`Delegate` helper relies on.
+
+### IAgileObject
+
+Almost every WinRT event source marshals its handlers between
+apartments. If `QueryInterface(IID_IAgileObject)` returns `E_NOINTERFACE`,
+the runtime falls back to slow proxying paths and (worse) some sources
+hard-fail with `RPC_E_WRONG_THREAD`. The handler **must** answer yes to
+`IID_IAgileObject` even though it has no methods of its own — return
+`self` and `AddRef`. M1 unit-tests this explicitly.
+
+### EventRegistrationToken
+
+The `add_*` family on event sources returns
+`Windows.Win32.System.WinRT.EventRegistrationToken` — a single `i64`
+field — by value. The corresponding `remove_*` takes that token by
+value. `0` is a **valid** token for some sources (notably statics-only
+event sources), so callers and the helper must not treat zero as
+"no registration". M1's helper preserves whatever the runtime hands
+back.
+
+## Carry-over plan (M0–M5)
+
+This is the M0 design landing. Implementation is staged across five
+PRs against `cataggar:zig`:
+
+| M  | Title                                       | Notes |
+|----|---------------------------------------------|-------|
+| M0 | Plan + ABI fix + design doc                 | This doc, the `IUnknown_Vtbl` base fix in `emitGenericInstantiations`, and the regression test. |
+| M1 | `win_core.Delegate` helper                  | Heap-allocated vtbl + 16-byte ref-count header, raw vtbl-style callback ABI, IAgileObject in QI, fired-once unit test. |
+| M2 | Event-pair detection in winbindgen          | Recognise `(add_X, remove_X)` pairs by signature shape. |
+| M3 | Sugar emission on interfaces                | `addX(self, callback, ctx) !EventToken` + `removeX(self, token) !void` per detected pair. |
+| M4 | Smoke sample                                | Live `winrt_event` sample using `IMemoryBufferReference.add_Closed`. |
+| M5 | Doc + close #14                             | Move bullet from "deferred" to "shipped"; finalise this doc. |
+
+## Reference implementation (M1 target)
+
+For concreteness, here is the shape M1 will land in `win-core`. This
+is intentionally written as a hand-built reference — the production
+code in M1 will be generic over `InvokeFn` and `iid` via comptime, but
+the runtime mechanics are exactly these.
+
+```zig
+// PSEUDO-CODE — see win-core/src/root.zig in M1 for the real version.
+
+const Header = extern struct {
+    vtbl: *const _Vtbl,           // points to a comptime-built static
+    refcount: std.atomic.Value(u32),
+    callback: *const InvokeFn,
+    ctx: ?*anyopaque,
+};
+
+fn QueryInterface(self: *Header, riid: *const GUID, ppv: *?*anyopaque) callconv(.c) HRESULT {
+    if (eq(riid, &IID_IUnknown) or eq(riid, &iid) or eq(riid, &IID_IAgileObject)) {
+        _ = self.refcount.fetchAdd(1, .acq_rel);
+        ppv.* = @ptrCast(self);
+        return S_OK;
+    }
+    ppv.* = null;
+    return E_NOINTERFACE;
+}
+
+fn AddRef(self: *Header) callconv(.c) u32 {
+    return self.refcount.fetchAdd(1, .acq_rel) + 1;
+}
+
+fn Release(self: *Header) callconv(.c) u32 {
+    const prev = self.refcount.fetchSub(1, .acq_rel);
+    if (prev == 1) std.heap.c_allocator.destroy(self);
+    return prev - 1;
+}
+
+fn Invoke(self: *Header, arg0: ..., arg1: ...) callconv(.c) HRESULT {
+    return self.callback(self.ctx, arg0, arg1);
+}
+
+// Public surface:
+pub fn Delegate(comptime InvokeFn: type, comptime iid: GUID) type {
+    return struct {
+        const Self = @This();
+        pub const _Vtbl = ...; // IUnknown + Invoke
+
+        pub fn init(callback: *const InvokeFn, ctx: ?*anyopaque) !*Self { ... }
+        pub fn asInterface(self: *Self) *anyopaque { return @ptrCast(self); }
+    };
+}
+```
+
+The caller wires it through M3-emitted sugar:
+
+```zig
+// M3 emits this method on IMemoryBufferReference:
+const token = try buf_ref.addClosed(&onClosed, @ptrCast(state));
+defer buf_ref.removeClosed(token) catch {};
+```
+
+## Lifetime and ownership
+
+- The `Delegate.init` allocation is owned by the runtime: every
+  successful `add_X` causes the runtime to `AddRef`, every fired
+  invocation comes through the same vtbl, and `remove_X` (or final
+  source teardown) hits `Release`. The Zig caller does **not**
+  free the allocation directly.
+- The `ctx` pointer is borrowed: the caller is responsible for
+  ensuring `ctx` outlives the registration. The ergonomic wrapper
+  in M5 may offer an arena-owned variant.
+- `EventToken` is `Copy` — pass by value freely.
+- A delegate that fires synchronously from inside `add_X` (some
+  sources do this when state is already in the target condition) is
+  legal and the helper handles it; the M4 smoke test exercises this.
+
+## Out of scope for #14
+
+- Non-`addX/removeX` event patterns (statics-only event sources,
+  e.g. `CoreApplication.Suspending`).
+- Async-bridge consumption of `TypedEventHandler` for
+  `IAsyncOperation.put_Completed` (issue #4 picks that up — the
+  delegate machinery here lands the foundation).
+- Multi-listener registries / weak-reference lifecycle. Callers
+  manage their own `EventToken`.
+- A Zig-friendly callback ABI (`fn(args...) !void` with HRESULT
+  translated). M0–M3 use the raw vtbl-style ABI for zero
+  translation cost; M5 may revisit.

--- a/zig/docs/winrt-v02-scope.md
+++ b/zig/docs/winrt-v02-scope.md
@@ -113,7 +113,9 @@ The heaviest milestone; landed in four phases.
 - **Generic delegates** (`EventHandler`1`, `TypedEventHandler`2`
   as first-class). They round-trip through the registry enough to
   unblock sigs that reference them, but there's no sugar for
-  add/remove-handler token dance.
+  add/remove-handler token dance. See
+  [generic-delegates.md](generic-delegates.md) for the carry-over
+  plan + ABI notes.
 
 **Phased bring-up:**
 
@@ -295,7 +297,8 @@ method sugar (e.g. `GetInt32ArrayOwned` → `![]i32`).
 ## Carry-overs into v0.3
 
 - **Async contracts** (M5 deferred above).
-- **Generic delegates** with add/remove-handler sugar.
+- **Generic delegates** with add/remove-handler sugar. Plan +
+  ABI notes: [generic-delegates.md](generic-delegates.md).
 - **Generic methods** (`.mvar_generic` still resolves to
   `UnsupportedElement`).
 - **`<Method>OwnedFromUtf16`** combined input-and-return HSTRING

--- a/zig/packages/winbindgen/src/root.zig
+++ b/zig/packages/winbindgen/src/root.zig
@@ -1925,7 +1925,27 @@ fn emitGenericInstantiations(
             const type_def_row = findTypeDefRow(file, tn.namespace, tn.name) orelse continue;
             const flags = file.cell(.type_def, type_def_row, 0);
             const is_winrt = (flags & winmd.TYPE_ATTR_WINDOWS_RUNTIME) != 0;
-            const base_vtbl = if (is_winrt) "IInspectable_Vtbl" else "IUnknown_Vtbl";
+
+            // WinRT *interfaces* extend `IInspectable`; WinRT *delegates*
+            // extend `System.MulticastDelegate` and inherit only the three
+            // `IUnknown` slots. Picking `IInspectable_Vtbl` for delegates
+            // would shift `Invoke` by three pointer-sized slots and the
+            // ABI would be silently wrong. See `zig/docs/generic-delegates.md`.
+            var is_delegate = false;
+            const extends_tok = file.cell(.type_def, type_def_row, 3);
+            if (extends_tok != 0) {
+                if (winmd.resolveTypeDefOrRefName(file, extends_tok)) |base| {
+                    if (std.mem.eql(u8, base.namespace, "System") and
+                        std.mem.eql(u8, base.name, "MulticastDelegate"))
+                    {
+                        is_delegate = true;
+                    }
+                } else |_| {}
+            }
+            const base_vtbl = if (is_delegate or !is_winrt)
+                "IUnknown_Vtbl"
+            else
+                "IInspectable_Vtbl";
 
             // Emit vtbl with substituted method signatures.
             try writer.print(
@@ -4938,6 +4958,39 @@ test "emitNamespace emits closed-generic instantiation for TypedEventHandler" {
 
     // No backticks in the output.
     try std.testing.expect(std.mem.indexOfScalar(u8, out, '`') == null);
+}
+
+test "closed-generic delegate vtbl uses IUnknown_Vtbl base, not IInspectable_Vtbl" {
+    // WinRT delegates extend `System.MulticastDelegate` and inherit only
+    // the three `IUnknown` slots. If the emitter picks `IInspectable_Vtbl`
+    // (which is correct for WinRT *interfaces*), `Invoke` shifts three
+    // pointer-sized slots and the ABI is silently wrong. Guard the
+    // foundation that issue #14's `win_core.Delegate` builds on.
+    const bytes = @embedFile("Windows.winmd");
+    var file = try winmd.parse(bytes);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer buf.deinit();
+
+    try emitNamespace(&buf.writer, arena.allocator(), &file, "Windows.Foundation", .x64);
+    const out = buf.written();
+
+    // The closed-generic TypedEventHandler vtbl must inherit IUnknown,
+    // not IInspectable.
+    const handler_vtbl_decl =
+        "pub const TypedEventHandler__G2__Windows_Foundation_IMemoryBufferReference__object_Vtbl = extern struct {";
+    const idx = std.mem.indexOf(u8, out, handler_vtbl_decl) orelse
+        return error.HandlerVtblNotEmitted;
+    const after = out[idx + handler_vtbl_decl.len ..];
+    const struct_end = std.mem.indexOfScalar(u8, after, '}') orelse return error.MalformedVtbl;
+    const body = after[0..struct_end];
+
+    try std.testing.expect(std.mem.indexOf(u8, body, "base: IUnknown_Vtbl") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "base: IInspectable_Vtbl") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "Invoke:") != null);
 }
 
 test "emitNamespaceEx accepts external generic seeds" {


### PR DESCRIPTION
M0 of issue #14 (generic delegates / add-remove-handler sugar).

## What

- **Latent ABI bug fix.** Closed-generic delegate instantiations in `emitGenericInstantiations` were unconditionally using `IInspectable_Vtbl` as the base. WinRT delegates extend `System.MulticastDelegate`, not `Object`, and have `IUnknown + Invoke` (4 slots), not `IInspectable + Invoke` (7 slots). The `Invoke` slot was therefore three slots too late. Doesn't bite anyone today (nothing in Zig constructs/calls these vtbls yet) but would silently break the M1 `Delegate` helper.
- **Regression test** in `winbindgen` asserts the closed-generic `TypedEventHandler` vtbl uses `base: IUnknown_Vtbl`, not `IInspectable_Vtbl`, and still has the `Invoke` slot.
- **New design doc** `zig/docs/generic-delegates.md` covering ABI, IAgileObject contract, EventRegistrationToken handling, lifetime, M0-M5 plan, and a reference impl shape for M1.
- **`winrt-v02-scope.md`** linked to the new doc from both the v0.2 deferred bullet and the v0.3 carry-over.

## Test

`zig build test` passes, including the new regression.

Refs #14.