### PR TITLE
zig: IAsyncOperation / async bridge (issue #4)

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1136,6 +1136,7 @@ pub fn build(b: *std.Build) void {
         "Windows.System",
         "Windows.System.Diagnostics",
         "Windows.System.RemoteSystems",
+        "Windows.System.Threading",
         "Windows.UI",
         "Windows.UI.Composition",
         "Windows.UI.Core",
@@ -1203,6 +1204,9 @@ pub fn build(b: *std.Build) void {
         \\    pub const Foundation = @import("Windows.Foundation.zig");
         \\    pub const Collections = @import("Windows.Foundation.Collections.zig");
         \\    pub const Globalization = @import("Windows.Globalization.zig");
+        \\    pub const System = struct {
+        \\        pub const Threading = @import("Windows.System.Threading.zig");
+        \\    };
         \\};
         \\
     ;
@@ -1398,6 +1402,11 @@ pub fn build(b: *std.Build) void {
         .{
             .name = "winrt-event-sugar",
             .root = "samples/winrt_event_sugar/main.zig",
+            .needs_win = true,
+        },
+        .{
+            .name = "winrt-async",
+            .root = "samples/winrt_async/main.zig",
             .needs_win = true,
         },
     };

--- a/zig/docs/async-bridge.md
+++ b/zig/docs/async-bridge.md
@@ -182,8 +182,8 @@ The completion handler delegate is constructed via the same
 
 ## Status
 
-- [ ] M0 plan + design doc (this file)
-- [ ] M1 `Async.wait` — IAsyncAction blocking wait
-- [ ] M2 `Async.waitResult` — IAsyncOperation<T>
-- [ ] M3 Sample + integration
-- [ ] M4 Doc + close #4
+- [x] M0 plan + design doc (commit `bf7190563`)
+- [x] M1 `Async.wait` — IAsyncAction blocking wait (commit `bf7190563`)
+- [x] M2 `Async.waitResult` — IAsyncOperation<T> (commit `08f331cf9`)
+- [x] M3 Sample + integration (commit `ad67d6aa4`)
+- [x] M4 Doc + close #4

--- a/zig/docs/async-bridge.md
+++ b/zig/docs/async-bridge.md
@@ -1,0 +1,189 @@
+# Async bridge — blocking wait for WinRT async contracts
+
+WinRT's four async contracts — `IAsyncAction`, `IAsyncOperation<T>`,
+`IAsyncActionWithProgress<P>`, `IAsyncOperationWithProgress<T,P>` —
+underpin virtually every modern Windows API. This document describes
+how the Zig projection bridges them with a minimal, safe helper in
+`win-core`.
+
+## The four contracts
+
+All four extend `IAsyncInfo`, which provides:
+
+| Method           | Returns       | Purpose                           |
+|------------------|---------------|-----------------------------------|
+| `get_Id`         | `u32`         | Opaque operation identifier       |
+| `get_Status`     | `AsyncStatus` | `Started`, `Completed`, `Canceled`, `Error` |
+| `get_ErrorCode`  | `HRESULT`     | Set when status is `Error`        |
+| `Cancel`         | `void`        | Request cancellation              |
+| `Close`          | `void`        | Release resources                 |
+
+Each concrete contract adds:
+
+| Contract                             | `put_Completed` handler type               | `GetResults` returns |
+|--------------------------------------|--------------------------------------------|----------------------|
+| `IAsyncAction`                       | `AsyncActionCompletedHandler`              | `void`               |
+| `IAsyncOperation<T>`                 | `AsyncOperationCompletedHandler<T>`        | `T`                  |
+| `IAsyncActionWithProgress<P>`        | `AsyncActionWithProgressCompletedHandler<P>` | `void`             |
+| `IAsyncOperationWithProgress<T,P>`   | `AsyncOperationWithProgressCompletedHandler<T,P>` | `T`           |
+
+## Design decision: block-on-signal
+
+Zig 0.16's `std.Io` async interface is still settling. Designing a
+native `async fn` bridge now risks a rewrite on 0.17. Instead, we use
+the same pattern Rust `windows-rs` uses internally:
+
+1. Create a Win32 manual-reset event (`CreateEventW`).
+2. Construct a completion-handler delegate whose `Invoke` body calls
+   `SetEvent` on that event handle.
+3. Register via `put_Completed`.
+4. `WaitForSingleObject(event, INFINITE)` — blocks the calling thread.
+5. After wakeup, read status and results.
+
+This is correct, simple, and works on every Windows version. A future
+v0.4+ milestone can layer `std.Io` on top without changing the public
+API shape.
+
+## API surface
+
+```zig
+const Async = win_core.Async;
+
+// IAsyncAction — no result
+try Async.wait(allocator, async_action);
+
+// IAsyncOperation<T> — returns T
+const value = try Async.waitResult(i32, allocator, async_op);
+```
+
+### `Async.wait`
+
+```zig
+pub fn wait(
+    allocator: std.mem.Allocator,
+    action: *IAsyncAction,
+) (hresult.Error || error{OutOfMemory})!void
+```
+
+Blocks until the async action completes. On success returns `void`.
+On failure propagates the operation's error code via `hresult.toError`.
+On cancellation returns `error.Aborted`.
+
+### `Async.waitResult`
+
+```zig
+pub fn waitResult(
+    comptime T: type,
+    allocator: std.mem.Allocator,
+    operation: *IAsyncOperation_T,
+) (hresult.Error || error{OutOfMemory})!T
+```
+
+Blocks until the async operation completes. Returns `T` (the result
+of `GetResults`). Same error propagation as `wait`.
+
+## Completion handler flow
+
+```
+caller
+  │
+  ▼
+Async.wait(allocator, async_action)
+  │
+  ├─ 1. CreateEventW(null, TRUE, FALSE, null) → hEvent
+  │
+  ├─ 2. Delegate(CompletedHandlerInvoke, handler_IID)
+  │      .create(allocator, &onCompleted, hEvent)
+  │      → COM delegate with refcount 1
+  │
+  ├─ 3. async_action.put_Completed(delegate)
+  │     (runtime AddRefs internally)
+  │
+  ├─ 4. WaitForSingleObject(hEvent, INFINITE)
+  │     ← blocks until onCompleted fires SetEvent
+  │
+  ├─ 5. QI async_action → IAsyncInfo
+  │     get_Status →
+  │       .Completed → GetResults → return void
+  │       .Canceled  → return error.Aborted
+  │       .Error     → get_ErrorCode → hresult.toError
+  │
+  ├─ 6. Delegate.release(delegate)
+  │
+  └─ 7. CloseHandle(hEvent)
+```
+
+The `onCompleted` delegate invoke body:
+
+```zig
+fn onCompleted(
+    this: *anyopaque,
+    _: *anyopaque,   // asyncInfo (unused — we QI separately)
+    _: AsyncStatus,  // status (unused — we read it separately)
+) callconv(.winapi) HRESULT {
+    const event_handle: HANDLE = @ptrCast(
+        Delegate.userData(this) orelse return hresult.E_FAIL,
+    );
+    _ = SetEvent(event_handle);
+    return hresult.S_OK;
+}
+```
+
+## Error propagation
+
+After the wait completes, the helper reads `IAsyncInfo.get_Status`:
+
+| `AsyncStatus` | Action |
+|---------------|--------|
+| `Completed`   | Call `GetResults()` and return normally. |
+| `Canceled`    | Return `error.Aborted` (matches `E_ABORT` semantics). |
+| `Error`       | Read `get_ErrorCode` → `hresult.toError(hr)`. The raw HRESULT is stashed in `hresult.last_hresult` for callers that need it. |
+
+## Delegate reuse
+
+The completion handler delegate is constructed via the same
+`win_core.Delegate(VtblInvokeFn, iid)` helper shipped in issue #14
+(see `zig/docs/generic-delegates.md`). The delegate:
+
+- Implements `QueryInterface` for `IUnknown`, `IAgileObject`, and the
+  handler's own IID.
+- Uses atomic ref-counting; freed when count hits zero.
+- Stores the Win32 event handle as `user_data`.
+
+## Lifetime and threading
+
+- The delegate is created with refcount 1. `put_Completed` AddRefs
+  internally. After registration the helper Releases its own
+  reference, leaving the runtime as sole owner.
+- The `onCompleted` body runs on whatever thread the async operation
+  completes on (typically an MTA thread pool thread). `SetEvent` is
+  inherently thread-safe.
+- Some operations complete synchronously within `put_Completed`. The
+  manual-reset event handles this: `SetEvent` fires before
+  `WaitForSingleObject`, which returns immediately.
+
+## What's deferred
+
+- **Progress handlers.** `IAsyncActionWithProgress<P>` and
+  `IAsyncOperationWithProgress<T,P>` have a `put_Progress` method.
+  The blocking wait works for completion; progress callbacks are
+  deferred.
+- **Cancellation tokens.** Callers can still call
+  `IAsyncInfo.Cancel()` directly on the raw interface. A structured
+  cancel-token abstraction is future work.
+- **Zig native async.** A `std.Io`-based non-blocking bridge is
+  deferred to v0.4+ when the Zig I/O interface stabilises.
+- **Timeout support.** `WaitForSingleObject` accepts a timeout in
+  milliseconds. Adding a timeout parameter is straightforward but
+  deferred to keep the initial API minimal.
+- **Emitter sugar.** Auto-wrapping async-returning methods with
+  blocking wait companions is deferred. Callers use `Async.wait` /
+  `Async.waitResult` explicitly.
+
+## Status
+
+- [ ] M0 plan + design doc (this file)
+- [ ] M1 `Async.wait` — IAsyncAction blocking wait
+- [ ] M2 `Async.waitResult` — IAsyncOperation<T>
+- [ ] M3 Sample + integration
+- [ ] M4 Doc + close #4

--- a/zig/docs/winrt-v02-scope.md
+++ b/zig/docs/winrt-v02-scope.md
@@ -176,12 +176,23 @@ The heaviest milestone; landed in four phases.
 
 ## M5 — Async contracts
 
-**Not shipped.** Zig 0.16's I/O interface shape was still settling
-during v0.2; designing `IAsyncOperation`1<T>` → `std.Io.async`
-risked a rewrite on 0.17. Deferred to v0.3.
+**Shipped (v0.3, issue #4).** `win_core.Async.wait` blocks on an
+`IAsyncAction` until completion; `Async.waitResult(T)` does the same
+for `IAsyncOperation<T>` and returns the result. Uses block-on-signal
+via Win32 `CreateEventW` / `WaitForSingleObject` (not Zig native async
+— that's deferred until `std.Io` stabilises). Error propagation reads
+`IAsyncInfo.get_Status` / `get_ErrorCode` and maps to `hresult.Error`.
+See `zig/docs/async-bridge.md`.
 
-Workaround for v0.2 consumers: drive `IAsyncOperation` manually by
-registering a `*Completion` callback and pumping the loop yourself.
+Sample: `zig/samples/winrt_async/main.zig` — `ThreadPool.RunAsync` →
+`Async.wait`.
+
+Carry-overs to v0.4:
+- Progress handlers (`IAsyncActionWithProgress<P>`,
+  `IAsyncOperationWithProgress<T,P>`).
+- Native Zig async/await integration (`std.Io`).
+- Cancellation tokens / timeout support.
+- Emitter sugar for async-returning methods.
 
 ## M6 — WinRT activation ergonomics
 
@@ -296,7 +307,9 @@ method sugar (e.g. `GetInt32ArrayOwned` → `![]i32`).
 
 ## Carry-overs into v0.3
 
-- **Async contracts** (M5 deferred above).
+- **Async contracts** — core shipped (M5 above, issue #4). Progress
+  variants, native async, cancellation tokens, emitter sugar carry
+  to v0.4.
 - **Generic methods** (`.mvar_generic` still resolves to
   `UnsupportedElement`).
 - **Cross-namespace generic delegate event sugar.** v0.2 emits

--- a/zig/packages/win-core/src/root.zig
+++ b/zig/packages/win-core/src/root.zig
@@ -559,7 +559,7 @@ pub const Async = struct {
 
     // -- Completion handler body ---------------------------------------------
 
-    fn onActionCompleted(
+    fn onCompleted(
         this: *anyopaque,
         _: *anyopaque,
         _: AsyncStatus,
@@ -570,18 +570,27 @@ pub const Async = struct {
         return hresult.S_OK;
     }
 
-    // -- Public API -----------------------------------------------------------
+    // -- Internals ------------------------------------------------------------
 
-    /// Block until an `IAsyncAction` completes. On success returns `void`;
-    /// on failure propagates the operation's error via `hresult.toError`.
-    ///
-    /// The `action` parameter must point at a COM object whose vtable starts
-    /// with `IInspectable_Vtbl` followed by the three `IAsyncAction` methods
-    /// (`put_Completed`, `get_Completed`, `GetResults`). This matches the
-    /// layout emitted by winbindgen for `Windows.Foundation.IAsyncAction`.
-    pub fn wait(
+    /// `IAsyncOperation<T>` vtable — extends `IInspectable`.
+    /// `GetResults` writes into an out-pointer of type `*T`.
+    pub fn IAsyncOperation_Vtbl(comptime T: type) type {
+        return extern struct {
+            base: IInspectable_Vtbl,
+            put_Completed: *const fn (this: *anyopaque, handler: *anyopaque) callconv(.winapi) HRESULT,
+            get_Completed: *const fn (this: *anyopaque, result: **anyopaque) callconv(.winapi) HRESULT,
+            GetResults: *const fn (this: *anyopaque, result: *T) callconv(.winapi) HRESULT,
+        };
+    }
+
+    /// Common blocking wait: create event → delegate → put_Completed → wait
+    /// → QI IAsyncInfo → check status. Returns the IAsyncInfo status.
+    /// On success the caller is responsible for calling GetResults.
+    fn blockUntilDone(
         allocator: std.mem.Allocator,
         action: *anyopaque,
+        put_completed_fn: *const fn (*anyopaque, *anyopaque) callconv(.winapi) HRESULT,
+        qi_fn: *const fn (*anyopaque, *const GUID, *?*anyopaque) callconv(.winapi) HRESULT,
     ) (hresult.Error || error{OutOfMemory})!void {
         // 1. Create manual-reset event (initially non-signaled).
         const event = CreateEventW(null, 1, 0, null) orelse
@@ -589,12 +598,15 @@ pub const Async = struct {
         defer _ = CloseHandle(event);
 
         // 2. Build the completion handler delegate.
+        // The IID doesn't actually matter for the runtime — it only needs to
+        // succeed QI for IAgileObject. We reuse the AsyncActionCompletedHandler
+        // IID since all four async completion handler types share the same
+        // three-arg invoke signature: (this, asyncInfo, status).
         const D = Delegate(CompletedHandlerInvokeFn, IID_AsyncActionCompletedHandler);
-        const handler = try D.create(allocator, &onActionCompleted, @ptrCast(event));
+        const handler = try D.create(allocator, &onCompleted, @ptrCast(event));
 
-        // 3. Register the handler via put_Completed.
-        const vtbl: *const IAsyncAction_Vtbl = @as(*const *const IAsyncAction_Vtbl, @ptrCast(@alignCast(action))).*;
-        const put_hr = vtbl.put_Completed(action, handler);
+        // 3. Register the handler.
+        const put_hr = put_completed_fn(action, handler);
         // Release our reference — the runtime AddRef'd on registration.
         _ = D.release(handler);
         if (hresult.failed(put_hr)) return hresult.toError(put_hr);
@@ -606,20 +618,19 @@ pub const Async = struct {
 
         // 5. QI for IAsyncInfo to read status and error code.
         var async_info: ?*anyopaque = null;
-        try hresult.ok(vtbl.base.base.QueryInterface(action, &IID_IAsyncInfo, &async_info));
+        try hresult.ok(qi_fn(action, &IID_IAsyncInfo, &async_info));
         const info_ptr = async_info orelse return hresult.toError(hresult.E_POINTER);
-        defer _ = @as(*const IAsyncInfo_Vtbl, @ptrCast(@alignCast(
-            @as(*const *const IAsyncInfo_Vtbl, @ptrCast(@alignCast(info_ptr))).*,
-        ))).base.base.Release(info_ptr);
+        const info_vtbl: *const IAsyncInfo_Vtbl = @as(
+            *const *const IAsyncInfo_Vtbl,
+            @ptrCast(@alignCast(info_ptr)),
+        ).*;
+        defer _ = info_vtbl.base.base.Release(info_ptr);
 
-        const info_vtbl: *const IAsyncInfo_Vtbl = @as(*const *const IAsyncInfo_Vtbl, @ptrCast(@alignCast(info_ptr))).*;
         var status: AsyncStatus = .Started;
         try hresult.ok(info_vtbl.get_Status(info_ptr, &status));
 
         switch (status) {
-            .Completed => {
-                try hresult.ok(vtbl.GetResults(action));
-            },
+            .Completed => return,
             .Canceled => return error.Aborted,
             .Error => {
                 var error_code: WinrtHResult = .{ .Value = 0 };
@@ -628,6 +639,59 @@ pub const Async = struct {
             },
             else => return hresult.toError(hresult.E_FAIL),
         }
+    }
+
+    // -- Public API -----------------------------------------------------------
+
+    /// Block until an `IAsyncAction` completes. On success returns `void`;
+    /// on failure propagates the operation's error via `hresult.toError`.
+    ///
+    /// The `action` parameter must point at a COM object whose vtable starts
+    /// with `IInspectable_Vtbl` followed by the three `IAsyncAction` methods
+    /// (`put_Completed`, `get_Completed`, `GetResults`). This matches the
+    /// layout emitted by winbindgen for `Windows.Foundation.IAsyncAction`.
+    ///
+    /// **Threading:** Must be called from an MTA thread. Calling from an STA
+    /// or UI thread will deadlock.
+    pub fn wait(
+        allocator: std.mem.Allocator,
+        action: *anyopaque,
+    ) (hresult.Error || error{OutOfMemory})!void {
+        const vtbl: *const IAsyncAction_Vtbl = @as(
+            *const *const IAsyncAction_Vtbl,
+            @ptrCast(@alignCast(action)),
+        ).*;
+
+        try blockUntilDone(allocator, action, vtbl.put_Completed, vtbl.base.base.QueryInterface);
+
+        // GetResults for IAsyncAction returns void on success.
+        try hresult.ok(vtbl.GetResults(action));
+    }
+
+    /// Block until an `IAsyncOperation<T>` completes and return the result.
+    ///
+    /// `T` is the result type (e.g. `i32`, `bool`, `*ISomething`).
+    /// The `operation` parameter must point at a COM object whose vtable
+    /// matches `IAsyncOperation<T>` layout: `IInspectable_Vtbl` base +
+    /// `put_Completed` + `get_Completed` + `GetResults(this, *T)`.
+    ///
+    /// **Threading:** Must be called from an MTA thread.
+    pub fn waitResult(
+        comptime T: type,
+        allocator: std.mem.Allocator,
+        operation: *anyopaque,
+    ) (hresult.Error || error{OutOfMemory})!T {
+        const Vtbl = IAsyncOperation_Vtbl(T);
+        const vtbl: *const Vtbl = @as(
+            *const *const Vtbl,
+            @ptrCast(@alignCast(operation)),
+        ).*;
+
+        try blockUntilDone(allocator, operation, vtbl.put_Completed, vtbl.base.base.QueryInterface);
+
+        var result: T = undefined;
+        try hresult.ok(vtbl.GetResults(operation, &result));
+        return result;
     }
 };
 
@@ -1612,4 +1676,174 @@ test "Async.wait propagates HRESULT for a failed IAsyncAction" {
     var mock = MockAsyncAction.init(.Error, hresult.E_ACCESSDENIED);
     const result = Async.wait(std.testing.allocator, @ptrCast(&mock));
     try std.testing.expectError(error.AccessDenied, result);
+}
+
+/// Mock IAsyncOperation<i32> for testing waitResult.
+const MockAsyncOperationI32 = struct {
+    vtbl_ptr: *const Async.IAsyncOperation_Vtbl(i32),
+    info_vtbl_ptr: *const Async.IAsyncInfo_Vtbl,
+    refcount: u32,
+    status: Async.AsyncStatus,
+    error_code: i32,
+    result_value: i32,
+
+    const op_vtbl = Async.IAsyncOperation_Vtbl(i32){
+        .base = .{
+            .base = .{
+                .QueryInterface = mockOpQI,
+                .AddRef = mockOpAddRef,
+                .Release = mockOpRelease,
+            },
+            .GetIids = MockAsyncAction.mockInspNoop3,
+            .GetRuntimeClassName = MockAsyncAction.mockInspClassName,
+            .GetTrustLevel = MockAsyncAction.mockInspTrustLevel,
+        },
+        .put_Completed = mockOpPutCompleted,
+        .get_Completed = mockOpGetCompleted,
+        .GetResults = mockOpGetResults,
+    };
+
+    const info_vtbl = Async.IAsyncInfo_Vtbl{
+        .base = .{
+            .base = .{
+                .QueryInterface = mockOpInfoQI,
+                .AddRef = mockOpInfoAddRef,
+                .Release = mockOpInfoRelease,
+            },
+            .GetIids = MockAsyncAction.mockInspNoop3,
+            .GetRuntimeClassName = MockAsyncAction.mockInspClassName,
+            .GetTrustLevel = MockAsyncAction.mockInspTrustLevel,
+        },
+        .get_Id = mockOpGetId,
+        .get_Status = mockOpGetStatus,
+        .get_ErrorCode = mockOpGetErrorCode,
+        .Cancel = mockOpCancel,
+        .Close = mockOpClose,
+    };
+
+    fn init(status: Async.AsyncStatus, error_code: i32, result_value: i32) MockAsyncOperationI32 {
+        return .{
+            .vtbl_ptr = &op_vtbl,
+            .info_vtbl_ptr = &info_vtbl,
+            .refcount = 1,
+            .status = status,
+            .error_code = error_code,
+            .result_value = result_value,
+        };
+    }
+
+    fn fromInfoFace(this: *anyopaque) *MockAsyncOperationI32 {
+        const ptr: [*]u8 = @ptrCast(this);
+        return @ptrCast(@alignCast(ptr - @offsetOf(MockAsyncOperationI32, "info_vtbl_ptr")));
+    }
+
+    fn mockOpQI(this: *anyopaque, riid: *const GUID, out: *?*anyopaque) callconv(.winapi) HRESULT {
+        if (std.meta.eql(riid.*, Async.IID_IAsyncInfo)) {
+            const self: *MockAsyncOperationI32 = @ptrCast(@alignCast(this));
+            self.refcount += 1;
+            out.* = @ptrCast(&self.info_vtbl_ptr);
+            return hresult.S_OK;
+        }
+        if (std.meta.eql(riid.*, IID_IUnknown)) {
+            const self: *MockAsyncOperationI32 = @ptrCast(@alignCast(this));
+            self.refcount += 1;
+            out.* = this;
+            return hresult.S_OK;
+        }
+        out.* = null;
+        return hresult.E_NOINTERFACE;
+    }
+
+    fn mockOpAddRef(this: *anyopaque) callconv(.winapi) u32 {
+        const self: *MockAsyncOperationI32 = @ptrCast(@alignCast(this));
+        self.refcount += 1;
+        return self.refcount;
+    }
+
+    fn mockOpRelease(this: *anyopaque) callconv(.winapi) u32 {
+        const self: *MockAsyncOperationI32 = @ptrCast(@alignCast(this));
+        if (self.refcount > 0) self.refcount -= 1;
+        return self.refcount;
+    }
+
+    fn mockOpInfoQI(this: *anyopaque, riid: *const GUID, out: *?*anyopaque) callconv(.winapi) HRESULT {
+        return mockOpQI(@ptrCast(fromInfoFace(this)), riid, out);
+    }
+    fn mockOpInfoAddRef(this: *anyopaque) callconv(.winapi) u32 {
+        return mockOpAddRef(@ptrCast(fromInfoFace(this)));
+    }
+    fn mockOpInfoRelease(this: *anyopaque) callconv(.winapi) u32 {
+        return mockOpRelease(@ptrCast(fromInfoFace(this)));
+    }
+
+    fn mockOpPutCompleted(this: *anyopaque, handler_ptr: *anyopaque) callconv(.winapi) HRESULT {
+        const self: *MockAsyncOperationI32 = @ptrCast(@alignCast(this));
+        const handler_vtbl: *const IUnknown_Vtbl =
+            @as(*const *const IUnknown_Vtbl, @ptrCast(@alignCast(handler_ptr))).*;
+        _ = handler_vtbl.AddRef(handler_ptr);
+        const d_vtbl = @as(
+            *const Delegate(Async.CompletedHandlerInvokeFn, Async.IID_AsyncActionCompletedHandler)._Vtbl,
+            @ptrCast(@alignCast(handler_vtbl)),
+        );
+        _ = d_vtbl.Invoke(handler_ptr, this, self.status);
+        _ = handler_vtbl.Release(handler_ptr);
+        return hresult.S_OK;
+    }
+
+    fn mockOpGetCompleted(_: *anyopaque, _: **anyopaque) callconv(.winapi) HRESULT {
+        return hresult.E_NOTIMPL;
+    }
+
+    fn mockOpGetResults(this: *anyopaque, result: *i32) callconv(.winapi) HRESULT {
+        const self: *MockAsyncOperationI32 = @ptrCast(@alignCast(this));
+        if (self.status == .Completed) {
+            result.* = self.result_value;
+            return hresult.S_OK;
+        }
+        return hresult.E_FAIL;
+    }
+
+    fn mockOpGetId(_: *anyopaque, result: *u32) callconv(.winapi) HRESULT {
+        result.* = 99;
+        return hresult.S_OK;
+    }
+
+    fn mockOpGetStatus(this: *anyopaque, result: *Async.AsyncStatus) callconv(.winapi) HRESULT {
+        const self = fromInfoFace(this);
+        result.* = self.status;
+        return hresult.S_OK;
+    }
+
+    fn mockOpGetErrorCode(this: *anyopaque, result: *Async.WinrtHResult) callconv(.winapi) HRESULT {
+        const self = fromInfoFace(this);
+        result.* = .{ .Value = self.error_code };
+        return hresult.S_OK;
+    }
+
+    fn mockOpCancel(_: *anyopaque) callconv(.winapi) HRESULT { return hresult.S_OK; }
+    fn mockOpClose(_: *anyopaque) callconv(.winapi) HRESULT { return hresult.S_OK; }
+};
+
+test "Async.waitResult returns result value for completed IAsyncOperation<i32>" {
+    if (@import("builtin").target.os.tag != .windows) return error.SkipZigTest;
+
+    var mock = MockAsyncOperationI32.init(.Completed, 0, 42);
+    const result = try Async.waitResult(i32, std.testing.allocator, @ptrCast(&mock));
+    try std.testing.expectEqual(@as(i32, 42), result);
+}
+
+test "Async.waitResult returns error.Aborted for canceled IAsyncOperation<i32>" {
+    if (@import("builtin").target.os.tag != .windows) return error.SkipZigTest;
+
+    var mock = MockAsyncOperationI32.init(.Canceled, 0, 0);
+    const result = Async.waitResult(i32, std.testing.allocator, @ptrCast(&mock));
+    try std.testing.expectError(error.Aborted, result);
+}
+
+test "Async.waitResult propagates HRESULT for failed IAsyncOperation<i32>" {
+    if (@import("builtin").target.os.tag != .windows) return error.SkipZigTest;
+
+    var mock = MockAsyncOperationI32.init(.Error, hresult.E_INVALIDARG, 0);
+    const result = Async.waitResult(i32, std.testing.allocator, @ptrCast(&mock));
+    try std.testing.expectError(error.InvalidArg, result);
 }

--- a/zig/packages/win-core/src/root.zig
+++ b/zig/packages/win-core/src/root.zig
@@ -480,6 +480,157 @@ pub fn Delegate(comptime VtblInvokeFn: type, comptime iid: GUID) type {
     };
 }
 
+// ---- Async ----------------------------------------------------------------
+
+/// Blocking wait helpers for WinRT async contracts (`IAsyncAction`,
+/// `IAsyncOperation<T>`). Uses a Win32 event + the `Delegate` helper to
+/// register a completion handler, blocks until the operation completes,
+/// then reads the status and propagates errors.
+///
+/// **Threading:** Must be called from an MTA thread. Calling from an STA
+/// or UI thread will deadlock because `WaitForSingleObject` cannot pump
+/// COM messages.
+///
+/// See `zig/docs/async-bridge.md` for the full design.
+pub const Async = struct {
+    // -- Local ABI definitions -----------------------------------------------
+    // Kept here so win-core stays self-contained (no dependency on the
+    // generated win/win-sys bundles).
+
+    pub const AsyncStatus = enum(i32) {
+        Started = 0,
+        Completed = 1,
+        Canceled = 2,
+        Error = 3,
+        _,
+    };
+
+    /// `Windows.Foundation.HResult` — a struct wrapping a plain `HRESULT`.
+    pub const WinrtHResult = extern struct { Value: i32 };
+
+    /// `IAsyncInfo` vtable — extends `IInspectable`.
+    pub const IAsyncInfo_Vtbl = extern struct {
+        base: IInspectable_Vtbl,
+        get_Id: *const fn (this: *anyopaque, result: *u32) callconv(.winapi) HRESULT,
+        get_Status: *const fn (this: *anyopaque, result: *AsyncStatus) callconv(.winapi) HRESULT,
+        get_ErrorCode: *const fn (this: *anyopaque, result: *WinrtHResult) callconv(.winapi) HRESULT,
+        Cancel: *const fn (this: *anyopaque) callconv(.winapi) HRESULT,
+        Close: *const fn (this: *anyopaque) callconv(.winapi) HRESULT,
+    };
+
+    pub const IID_IAsyncInfo = GUID.parse("00000036-0000-0000-C000-000000000046");
+
+    /// `IAsyncAction` vtable — extends `IInspectable`.
+    /// `put_Completed` takes `*anyopaque` because `AsyncActionCompletedHandler`
+    /// is opaque in the generated bindings (a delegate, not an interface).
+    pub const IAsyncAction_Vtbl = extern struct {
+        base: IInspectable_Vtbl,
+        put_Completed: *const fn (this: *anyopaque, handler: *anyopaque) callconv(.winapi) HRESULT,
+        get_Completed: *const fn (this: *anyopaque, result: **anyopaque) callconv(.winapi) HRESULT,
+        GetResults: *const fn (this: *anyopaque) callconv(.winapi) HRESULT,
+    };
+
+    /// `AsyncActionCompletedHandler.Invoke` signature.
+    /// `fn(this, asyncInfo: *IAsyncAction, status: AsyncStatus) -> HRESULT`
+    /// We use `*anyopaque` for all COM interface pointers.
+    const CompletedHandlerInvokeFn =
+        fn (this: *anyopaque, asyncInfo: *anyopaque, status: AsyncStatus) callconv(.winapi) HRESULT;
+
+    /// IID for `AsyncActionCompletedHandler`:
+    /// {A4ED5C81-76C9-40BD-8BE6-B1D90FB20AE7}
+    const IID_AsyncActionCompletedHandler = GUID.parse("A4ED5C81-76C9-40BD-8BE6-B1D90FB20AE7");
+
+    // -- Win32 sync primitives -----------------------------------------------
+
+    const HANDLE = *anyopaque;
+    const INFINITE: u32 = 0xFFFFFFFF;
+    const WAIT_OBJECT_0: u32 = 0;
+
+    extern "kernel32" fn CreateEventW(
+        lpEventAttributes: ?*anyopaque,
+        bManualReset: BOOL,
+        bInitialState: BOOL,
+        lpName: ?[*:0]const u16,
+    ) callconv(.winapi) ?HANDLE;
+
+    extern "kernel32" fn SetEvent(hEvent: HANDLE) callconv(.winapi) BOOL;
+    extern "kernel32" fn WaitForSingleObject(hHandle: HANDLE, dwMilliseconds: u32) callconv(.winapi) u32;
+    extern "kernel32" fn CloseHandle(hObject: HANDLE) callconv(.winapi) BOOL;
+
+    // -- Completion handler body ---------------------------------------------
+
+    fn onActionCompleted(
+        this: *anyopaque,
+        _: *anyopaque,
+        _: AsyncStatus,
+    ) callconv(.winapi) HRESULT {
+        const D = Delegate(CompletedHandlerInvokeFn, IID_AsyncActionCompletedHandler);
+        const event_handle: HANDLE = @ptrCast(D.userData(this) orelse return hresult.E_FAIL);
+        _ = SetEvent(event_handle);
+        return hresult.S_OK;
+    }
+
+    // -- Public API -----------------------------------------------------------
+
+    /// Block until an `IAsyncAction` completes. On success returns `void`;
+    /// on failure propagates the operation's error via `hresult.toError`.
+    ///
+    /// The `action` parameter must point at a COM object whose vtable starts
+    /// with `IInspectable_Vtbl` followed by the three `IAsyncAction` methods
+    /// (`put_Completed`, `get_Completed`, `GetResults`). This matches the
+    /// layout emitted by winbindgen for `Windows.Foundation.IAsyncAction`.
+    pub fn wait(
+        allocator: std.mem.Allocator,
+        action: *anyopaque,
+    ) (hresult.Error || error{OutOfMemory})!void {
+        // 1. Create manual-reset event (initially non-signaled).
+        const event = CreateEventW(null, 1, 0, null) orelse
+            return hresult.toError(hresult.E_FAIL);
+        defer _ = CloseHandle(event);
+
+        // 2. Build the completion handler delegate.
+        const D = Delegate(CompletedHandlerInvokeFn, IID_AsyncActionCompletedHandler);
+        const handler = try D.create(allocator, &onActionCompleted, @ptrCast(event));
+
+        // 3. Register the handler via put_Completed.
+        const vtbl: *const IAsyncAction_Vtbl = @as(*const *const IAsyncAction_Vtbl, @ptrCast(@alignCast(action))).*;
+        const put_hr = vtbl.put_Completed(action, handler);
+        // Release our reference — the runtime AddRef'd on registration.
+        _ = D.release(handler);
+        if (hresult.failed(put_hr)) return hresult.toError(put_hr);
+
+        // 4. Block until the handler fires SetEvent.
+        const wait_result = WaitForSingleObject(event, INFINITE);
+        if (wait_result != WAIT_OBJECT_0)
+            return hresult.toError(hresult.E_FAIL);
+
+        // 5. QI for IAsyncInfo to read status and error code.
+        var async_info: ?*anyopaque = null;
+        try hresult.ok(vtbl.base.base.QueryInterface(action, &IID_IAsyncInfo, &async_info));
+        const info_ptr = async_info orelse return hresult.toError(hresult.E_POINTER);
+        defer _ = @as(*const IAsyncInfo_Vtbl, @ptrCast(@alignCast(
+            @as(*const *const IAsyncInfo_Vtbl, @ptrCast(@alignCast(info_ptr))).*,
+        ))).base.base.Release(info_ptr);
+
+        const info_vtbl: *const IAsyncInfo_Vtbl = @as(*const *const IAsyncInfo_Vtbl, @ptrCast(@alignCast(info_ptr))).*;
+        var status: AsyncStatus = .Started;
+        try hresult.ok(info_vtbl.get_Status(info_ptr, &status));
+
+        switch (status) {
+            .Completed => {
+                try hresult.ok(vtbl.GetResults(action));
+            },
+            .Canceled => return error.Aborted,
+            .Error => {
+                var error_code: WinrtHResult = .{ .Value = 0 };
+                _ = info_vtbl.get_ErrorCode(info_ptr, &error_code);
+                return hresult.toError(error_code.Value);
+            },
+            else => return hresult.toError(hresult.E_FAIL),
+        }
+    }
+};
+
 // ---- BSTR -----------------------------------------------------------------
 
 /// Raw OLE Automation string: a UTF-16LE `[*]const u16` whose four bytes
@@ -1257,4 +1408,208 @@ test "activateInstance constructs a parameterless WinRT class" {
     try hresult.ok(inst.vtbl().GetTrustLevel(inst.ptr, &trust));
     try std.testing.expect(trust >= @intFromEnum(TrustLevel.base_trust) and
         trust <= @intFromEnum(TrustLevel.full_trust));
+}
+
+// ---- Async tests -----------------------------------------------------------
+
+/// Mock IAsyncAction that completes synchronously when put_Completed is called.
+/// The completion handler is invoked immediately during put_Completed with the
+/// configured status, simulating the "already-completed" fast path.
+const MockAsyncAction = struct {
+    /// First field MUST be the vtable pointer (COM ABI contract).
+    vtbl_ptr: *const Async.IAsyncAction_Vtbl,
+    /// Second vtable pointer for the IAsyncInfo face.
+    info_vtbl_ptr: *const Async.IAsyncInfo_Vtbl,
+    refcount: u32,
+    status: Async.AsyncStatus,
+    error_code: i32,
+    handler: ?*anyopaque,
+
+    const action_vtbl = Async.IAsyncAction_Vtbl{
+        .base = .{
+            .base = .{
+                .QueryInterface = mockQI,
+                .AddRef = mockAddRef,
+                .Release = mockRelease,
+            },
+            .GetIids = mockInspNoop3,
+            .GetRuntimeClassName = mockInspClassName,
+            .GetTrustLevel = mockInspTrustLevel,
+        },
+        .put_Completed = mockPutCompleted,
+        .get_Completed = mockGetCompleted,
+        .GetResults = mockGetResults,
+    };
+
+    const info_vtbl = Async.IAsyncInfo_Vtbl{
+        .base = .{
+            .base = .{
+                .QueryInterface = mockInfoQI,
+                .AddRef = mockInfoAddRef,
+                .Release = mockInfoRelease,
+            },
+            .GetIids = mockInspNoop3,
+            .GetRuntimeClassName = mockInspClassName,
+            .GetTrustLevel = mockInspTrustLevel,
+        },
+        .get_Id = mockGetId,
+        .get_Status = mockGetStatus,
+        .get_ErrorCode = mockGetErrorCode,
+        .Cancel = mockCancel,
+        .Close = mockClose,
+    };
+
+    fn init(status: Async.AsyncStatus, error_code: i32) MockAsyncAction {
+        return .{
+            .vtbl_ptr = &action_vtbl,
+            .info_vtbl_ptr = &info_vtbl,
+            .refcount = 1,
+            .status = status,
+            .error_code = error_code,
+            .handler = null,
+        };
+    }
+
+    /// Recover the owning MockAsyncAction from the IAsyncInfo face pointer.
+    fn fromInfoFace(this: *anyopaque) *MockAsyncAction {
+        const ptr: [*]u8 = @ptrCast(this);
+        return @ptrCast(@alignCast(ptr - @offsetOf(MockAsyncAction, "info_vtbl_ptr")));
+    }
+
+    // -- IAsyncAction face (this == &mock) -----------------------------------
+
+    fn mockQI(this: *anyopaque, riid: *const GUID, out: *?*anyopaque) callconv(.winapi) HRESULT {
+        if (std.meta.eql(riid.*, Async.IID_IAsyncInfo)) {
+            const self: *MockAsyncAction = @ptrCast(@alignCast(this));
+            self.refcount += 1;
+            out.* = @ptrCast(&self.info_vtbl_ptr);
+            return hresult.S_OK;
+        }
+        if (std.meta.eql(riid.*, IID_IUnknown)) {
+            const self: *MockAsyncAction = @ptrCast(@alignCast(this));
+            self.refcount += 1;
+            out.* = this;
+            return hresult.S_OK;
+        }
+        out.* = null;
+        return hresult.E_NOINTERFACE;
+    }
+
+    fn mockAddRef(this: *anyopaque) callconv(.winapi) u32 {
+        const self: *MockAsyncAction = @ptrCast(@alignCast(this));
+        self.refcount += 1;
+        return self.refcount;
+    }
+
+    fn mockRelease(this: *anyopaque) callconv(.winapi) u32 {
+        const self: *MockAsyncAction = @ptrCast(@alignCast(this));
+        if (self.refcount > 0) self.refcount -= 1;
+        return self.refcount;
+    }
+
+    // -- IAsyncInfo face (this == &mock.info_vtbl_ptr) -----------------------
+
+    fn mockInfoQI(this: *anyopaque, riid: *const GUID, out: *?*anyopaque) callconv(.winapi) HRESULT {
+        return mockQI(@ptrCast(fromInfoFace(this)), riid, out);
+    }
+
+    fn mockInfoAddRef(this: *anyopaque) callconv(.winapi) u32 {
+        return mockAddRef(@ptrCast(fromInfoFace(this)));
+    }
+
+    fn mockInfoRelease(this: *anyopaque) callconv(.winapi) u32 {
+        return mockRelease(@ptrCast(fromInfoFace(this)));
+    }
+
+    // -- IInspectable stubs --------------------------------------------------
+
+    fn mockInspNoop3(_: *anyopaque, _: *u32, _: *?[*]GUID) callconv(.winapi) HRESULT {
+        return hresult.E_NOTIMPL;
+    }
+    fn mockInspClassName(_: *anyopaque, _: *HSTRING) callconv(.winapi) HRESULT {
+        return hresult.E_NOTIMPL;
+    }
+    fn mockInspTrustLevel(_: *anyopaque, _: *i32) callconv(.winapi) HRESULT {
+        return hresult.E_NOTIMPL;
+    }
+
+    // -- IAsyncAction methods ------------------------------------------------
+
+    fn mockPutCompleted(this: *anyopaque, handler_ptr: *anyopaque) callconv(.winapi) HRESULT {
+        const self: *MockAsyncAction = @ptrCast(@alignCast(this));
+        self.handler = handler_ptr;
+        // AddRef the handler (as a real runtime would).
+        const handler_vtbl: *const IUnknown_Vtbl =
+            @as(*const *const IUnknown_Vtbl, @ptrCast(@alignCast(handler_ptr))).*;
+        _ = handler_vtbl.AddRef(handler_ptr);
+        // Fire synchronously (simulating already-completed).
+        const d_vtbl = @as(
+            *const Delegate(Async.CompletedHandlerInvokeFn, Async.IID_AsyncActionCompletedHandler)._Vtbl,
+            @ptrCast(@alignCast(handler_vtbl)),
+        );
+        _ = d_vtbl.Invoke(handler_ptr, this, self.status);
+        // Release runtime's reference.
+        _ = handler_vtbl.Release(handler_ptr);
+        return hresult.S_OK;
+    }
+
+    fn mockGetCompleted(_: *anyopaque, _: **anyopaque) callconv(.winapi) HRESULT {
+        return hresult.E_NOTIMPL;
+    }
+
+    fn mockGetResults(this: *anyopaque) callconv(.winapi) HRESULT {
+        const self: *MockAsyncAction = @ptrCast(@alignCast(this));
+        if (self.status == .Completed) return hresult.S_OK;
+        return hresult.E_FAIL;
+    }
+
+    // -- IAsyncInfo methods --------------------------------------------------
+
+    fn mockGetId(_: *anyopaque, result: *u32) callconv(.winapi) HRESULT {
+        result.* = 42;
+        return hresult.S_OK;
+    }
+
+    fn mockGetStatus(this: *anyopaque, result: *Async.AsyncStatus) callconv(.winapi) HRESULT {
+        const self = fromInfoFace(this);
+        result.* = self.status;
+        return hresult.S_OK;
+    }
+
+    fn mockGetErrorCode(this: *anyopaque, result: *Async.WinrtHResult) callconv(.winapi) HRESULT {
+        const self = fromInfoFace(this);
+        result.* = .{ .Value = self.error_code };
+        return hresult.S_OK;
+    }
+
+    fn mockCancel(_: *anyopaque) callconv(.winapi) HRESULT {
+        return hresult.S_OK;
+    }
+
+    fn mockClose(_: *anyopaque) callconv(.winapi) HRESULT {
+        return hresult.S_OK;
+    }
+};
+
+test "Async.wait succeeds for a synchronously-completed IAsyncAction" {
+    if (@import("builtin").target.os.tag != .windows) return error.SkipZigTest;
+
+    var mock = MockAsyncAction.init(.Completed, 0);
+    try Async.wait(std.testing.allocator, @ptrCast(&mock));
+}
+
+test "Async.wait returns error.Aborted for a canceled IAsyncAction" {
+    if (@import("builtin").target.os.tag != .windows) return error.SkipZigTest;
+
+    var mock = MockAsyncAction.init(.Canceled, 0);
+    const result = Async.wait(std.testing.allocator, @ptrCast(&mock));
+    try std.testing.expectError(error.Aborted, result);
+}
+
+test "Async.wait propagates HRESULT for a failed IAsyncAction" {
+    if (@import("builtin").target.os.tag != .windows) return error.SkipZigTest;
+
+    var mock = MockAsyncAction.init(.Error, hresult.E_ACCESSDENIED);
+    const result = Async.wait(std.testing.allocator, @ptrCast(&mock));
+    try std.testing.expectError(error.AccessDenied, result);
 }

--- a/zig/packages/win-core/src/root.zig
+++ b/zig/packages/win-core/src/root.zig
@@ -1820,8 +1820,12 @@ const MockAsyncOperationI32 = struct {
         return hresult.S_OK;
     }
 
-    fn mockOpCancel(_: *anyopaque) callconv(.winapi) HRESULT { return hresult.S_OK; }
-    fn mockOpClose(_: *anyopaque) callconv(.winapi) HRESULT { return hresult.S_OK; }
+    fn mockOpCancel(_: *anyopaque) callconv(.winapi) HRESULT {
+        return hresult.S_OK;
+    }
+    fn mockOpClose(_: *anyopaque) callconv(.winapi) HRESULT {
+        return hresult.S_OK;
+    }
 };
 
 test "Async.waitResult returns result value for completed IAsyncOperation<i32>" {

--- a/zig/samples/winrt_async/main.zig
+++ b/zig/samples/winrt_async/main.zig
@@ -1,0 +1,83 @@
+//! WinRT async-bridge canary — exercises `win_core.Async.wait`
+//! on a real `IAsyncAction` returned by `ThreadPool.RunAsync`.
+//!
+//! Pipeline validated:
+//!   1. `ThreadPool.statics()` → activation factory for the static class.
+//!   2. `Delegate` creates a `WorkItemHandler` whose `Invoke` body
+//!      increments a counter (proving the work item ran).
+//!   3. `RunAsync(handler)` → `IAsyncAction`.
+//!   4. `Async.wait(allocator, action)` blocks until the thread-pool
+//!      work item completes.
+//!   5. After `wait` returns, the counter proves the work item fired.
+//!
+//! Build:  `zig build winrt-async`
+//! Run:    `.\zig-out\bin\winrt-async.exe`
+
+const std = @import("std");
+const win = @import("win");
+
+const core = win.core;
+const HRESULT = core.HRESULT;
+const Async = core.Async;
+
+const Foundation = win.WinRT.Foundation;
+const Threading = win.WinRT.System.Threading;
+const ThreadPool = Threading.ThreadPool;
+
+/// IID for WorkItemHandler: {1D1A8B8B-FA66-414F-9CBD-B65FC99D17FA}
+const IID_WorkItemHandler = core.GUID.parse("1D1A8B8B-FA66-414F-9CBD-B65FC99D17FA");
+
+/// WorkItemHandler.Invoke signature: fn(this, asyncAction) -> HRESULT
+const WorkItemInvokeFn = fn (this: *anyopaque, asyncAction: *anyopaque) callconv(.winapi) HRESULT;
+
+const WorkState = struct {
+    fired: std.atomic.Value(u32),
+};
+
+fn onWorkItem(this: *anyopaque, _: *anyopaque) callconv(.winapi) HRESULT {
+    const D = core.Delegate(WorkItemInvokeFn, IID_WorkItemHandler);
+    const ud = D.userData(this) orelse return core.hresult.E_FAIL;
+    const state: *WorkState = @ptrCast(@alignCast(ud));
+    _ = state.fired.fetchAdd(1, .release);
+    return core.hresult.S_OK;
+}
+
+pub fn main() !void {
+    // MTA required for async bridge.
+    try core.roInitialize(.multi_threaded);
+    defer core.winrt.RoUninitialize();
+
+    const allocator = std.heap.page_allocator;
+
+    // 1. Get ThreadPool statics.
+    const pool = try ThreadPool.statics();
+    defer pool.deinit();
+
+    // 2. Create a WorkItemHandler delegate.
+    var state = WorkState{ .fired = std.atomic.Value(u32).init(0) };
+    const D = core.Delegate(WorkItemInvokeFn, IID_WorkItemHandler);
+    const handler = D.create(allocator, &onWorkItem, @ptrCast(&state)) catch |e| {
+        std.debug.print("Failed to create work item handler: {}\n", .{e});
+        return error.DelegateFailed;
+    };
+
+    // 3. Call ThreadPool.RunAsync → IAsyncAction
+    var action: *Foundation.IAsyncAction = undefined;
+    const statics_ptr: *const Threading.IThreadPoolStatics = @ptrCast(@alignCast(pool.ptr));
+    try core.hresult.ok(statics_ptr.RunAsync(@ptrCast(handler), @ptrCast(&action)));
+    defer _ = action.Release();
+
+    // Release our delegate reference — runtime AddRef'd.
+    _ = D.release(handler);
+
+    // 4. Block until the work item completes.
+    try Async.wait(allocator, @ptrCast(action));
+
+    // 5. Verify the work item fired.
+    const count = state.fired.load(.acquire);
+    std.debug.print("ThreadPool work item fired {d} time(s) (expected 1)\n", .{count});
+    if (count != 1) {
+        std.debug.print("ERROR: expected exactly 1 invocation\n", .{});
+        return error.WorkItemNotFired;
+    }
+}


### PR DESCRIPTION
## Summary

Delivers `win_core.Async` — blocking wait helpers for WinRT async contracts, built on the Delegate infrastructure from #14.

### API surface

- `Async.wait(allocator, *IAsyncAction) !void` — blocks until an IAsyncAction completes
- `Async.waitResult(comptime T, allocator, *IAsyncOperation) !T` — blocks and returns the result

### Commits

| M | Title | Change |
|---|-------|--------|
| M0+M1 | Design doc + Async.wait | `zig/docs/async-bridge.md` + `win_core.Async.wait` with 3 mock tests |
| M2 | waitResult | `Async.waitResult(T)` for `IAsyncOperation<T>` with 3 more tests |
| M3 | Sample | `zig/samples/winrt_async/` — `ThreadPool.RunAsync` + `Async.wait` |
| M4 | Docs | Shipped status in async-bridge.md and winrt-v02-scope.md |

### Design decisions

- Block-on-signal (CreateEventW + WaitForSingleObject), not Zig native async
- All ABI types (IAsyncInfo_Vtbl, AsyncStatus, etc.) defined locally in win-core
- Reuses Delegate from #14 for completion handler construction
- MTA-only constraint documented

Closes #4