### PR TITLE
zig: OwnedFromUtf16 combined HSTRING sugar (issue #16)

### DIFF
--- a/zig/docs/winrt-v02-scope.md
+++ b/zig/docs/winrt-v02-scope.md
@@ -318,5 +318,7 @@ method sugar (e.g. `GetInt32ArrayOwned` → `![]i32`).
   v0.2 corpus). Cross-namespace delegates need import plumbing on
   the host side; tracked separately. See
   [generic-delegates.md](generic-delegates.md).
-- **`<Method>OwnedFromUtf16`** combined input-and-return HSTRING
-  sugar, once a sample demands it.
+- **`<Method>OwnedFromUtf16`** — shipped (issue #16). Combined
+  input-and-return HSTRING sugar for methods that take `HSTRING` in
+  and return `HSTRING` out. Accepts `[]const u16`, returns
+  `!win_core.Hstring`.

--- a/zig/packages/winbindgen/src/root.zig
+++ b/zig/packages/winbindgen/src/root.zig
@@ -3069,6 +3069,43 @@ fn writeMethodWrapper(
         try writer.writeAll("        return win_core.Hstring.fromRaw(r);\n");
         try writer.writeAll("    }\n");
     }
+
+    // Combined sugar: if the method has HSTRING input AND returns HSTRING
+    // via split out-param, emit `<Method>OwnedFromUtf16` that accepts
+    // `[]const u16` inputs and returns `!win_core.Hstring`.
+    if (has_hstring_in and split_return and sig.return_type == .string and !has_array_param) {
+        try writer.print("    pub fn {s}OwnedFromUtf16(self: *const {s}", .{ method_name, this_name });
+        for (sig.params, 0..) |p, i| {
+            try writer.print(", p{d}: ", .{i});
+            if (p == .string) {
+                try writer.writeAll("[]const u16");
+            } else {
+                try writeParam(writer, arena, p, current_namespace, cross);
+            }
+        }
+        try writer.writeAll(") !win_core.Hstring {\n");
+        for (sig.params, 0..) |p, i| {
+            if (p == .string) {
+                try writer.print(
+                    "        var h{d} = win_core.Hstring.create(p{d}) catch return error.OutOfMemory;\n",
+                    .{ i, i },
+                );
+                try writer.print("        defer h{d}.deinit();\n", .{i});
+            }
+        }
+        try writer.writeAll("        var r: HSTRING = null;\n");
+        try writer.print("        try win_core.hresult.ok(self.vtable.@\"{s}\"(self", .{vtbl_field_name});
+        for (sig.params, 0..) |p, i| {
+            if (p == .string) {
+                try writer.print(", h{d}.raw", .{i});
+            } else {
+                try writer.print(", p{d}", .{i});
+            }
+        }
+        try writer.writeAll(", &r));\n");
+        try writer.writeAll("        return win_core.Hstring.fromRaw(r);\n");
+        try writer.writeAll("    }\n");
+    }
 }
 
 /// Emit a function-pointer type for a single MethodDef row, WinRT-ABI
@@ -4468,6 +4505,36 @@ test "emitInterfaceHandles writes IStringable handle with method wrappers" {
     // Non-HSTRING-returning methods (e.g. IClosable.Close, which is
     // void/HRESULT-only) should NOT get an `Owned` companion.
     try std.testing.expect(std.mem.indexOf(u8, out, "CloseOwned") == null);
+
+    // Combined sugar: `IUriEscapeStatics.UnescapeComponent` takes HSTRING
+    // in AND returns HSTRING out, so the emitter should produce an
+    // `UnescapeComponentOwnedFromUtf16` companion that accepts `[]const u16`
+    // and returns `!win_core.Hstring`.
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        out,
+        "pub fn UnescapeComponentOwnedFromUtf16(self: *const IUriEscapeStatics, p0: []const u16) !win_core.Hstring {",
+    ) != null);
+    // Input HSTRING is created from the slice and deferred.
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        out,
+        "var h0 = win_core.Hstring.create(p0) catch return error.OutOfMemory;",
+    ) != null);
+    // Output HSTRING is wrapped in owning Hstring.
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        out,
+        "try win_core.hresult.ok(self.vtable.@\"UnescapeComponent\"(self, h0.raw, &r));",
+    ) != null);
+
+    // Methods that only have HSTRING input but non-HSTRING output
+    // (e.g. CreateUri returns **Uri) should NOT get OwnedFromUtf16.
+    try std.testing.expect(std.mem.indexOf(u8, out, "CreateUriOwnedFromUtf16") == null);
+
+    // Methods with no HSTRING input (e.g. ToString) should NOT get
+    // OwnedFromUtf16 either.
+    try std.testing.expect(std.mem.indexOf(u8, out, "ToStringOwnedFromUtf16") == null);
 
     // Many interfaces should have been emitted.
     var count: usize = 0;


### PR DESCRIPTION
Emits `<Method>OwnedFromUtf16` for WinRT methods with HSTRING input AND HSTRING output.

Combines the existing `FromUtf16` (input sugar) and `Owned` (output sugar) into a single call:

`zig
// Before: pick one, hand-roll the other
var result: HSTRING = null;
try hresult.ok(s.UnescapeComponentFromUtf16(slice, &result));
var owned = Hstring.fromRaw(result);
defer owned.deinit();

// After
var owned = try s.UnescapeComponentOwnedFromUtf16(slice);
defer owned.deinit();
`

Snapshot tests verify positive and negative cases. No runtime changes.

Closes #16