### PR TITLE
zig: port message_box and enum_windows samples

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1409,6 +1409,14 @@ pub fn build(b: *std.Build) void {
             .root = "samples/winrt_async/main.zig",
             .needs_win = true,
         },
+        .{
+            .name = "message-box",
+            .root = "samples/message_box/main.zig",
+        },
+        .{
+            .name = "enum-windows",
+            .root = "samples/enum_windows/main.zig",
+        },
     };
 
     for (samples) |s| {

--- a/zig/samples/enum_windows/main.zig
+++ b/zig/samples/enum_windows/main.zig
@@ -1,0 +1,42 @@
+//! Port of `crates/samples/windows/enum_windows` — enumerates
+//! top-level windows and prints their titles.
+//!
+//! Exercises the callback pattern: `EnumWindows` takes a `WNDENUMPROC`
+//! (a Win32 callback) that is invoked once per top-level window.
+//!
+//! Build:  `zig build enum-windows`
+//! Run:    `.\zig-out\bin\enum-windows.exe`
+
+const std = @import("std");
+const win_sys = @import("win-sys");
+
+const win = win_sys.project(.{
+    .@"Windows.Win32.UI.WindowsAndMessaging" = .{
+        "EnumWindows",
+        "GetWindowTextW",
+        "IsWindowVisible",
+    },
+});
+
+fn enumWindowCallback(hwnd: ?*anyopaque, _: isize) callconv(.winapi) i32 {
+    // Skip invisible windows.
+    if (win.IsWindowVisible(hwnd) == 0) return 1;
+
+    // GetWindowTextW expects PWSTR (mutable).
+    var text_buf: [512]u16 = undefined;
+    const len = win.GetWindowTextW(hwnd, @ptrCast(&text_buf), 512);
+    if (len <= 0) return 1;
+
+    // Convert UTF-16 title to UTF-8 for printing.
+    var utf8_buf: [1024]u8 = undefined;
+    const n = std.unicode.utf16LeToUtf8(&utf8_buf, text_buf[0..@intCast(len)]) catch 0;
+    if (n > 0) {
+        std.debug.print("{s}\n", .{utf8_buf[0..n]});
+    }
+
+    return 1; // continue
+}
+
+pub fn main() void {
+    _ = win.EnumWindows(@ptrCast(&enumWindowCallback), 0);
+}

--- a/zig/samples/message_box/main.zig
+++ b/zig/samples/message_box/main.zig
@@ -1,0 +1,26 @@
+//! Port of `crates/samples/windows/message_box` — the simplest
+//! possible Win32 GUI sample. Shows a message box and exits.
+//!
+//! Build:  `zig build message-box`
+//! Run:    `.\zig-out\bin\message-box.exe`
+
+const win_sys = @import("win-sys");
+
+const win = win_sys.project(.{
+    .@"Windows.Win32.UI.WindowsAndMessaging" = .{"MessageBoxW"},
+});
+
+pub fn main() void {
+    // MessageBoxW expects PWSTR (mutable) for the Win32 ABI.
+    // Use mutable arrays so the pointer types match.
+    var text = toUtf16("Hello from Zig!");
+    var caption = toUtf16("windows-rs / Zig");
+    _ = win.MessageBoxW(null, @ptrCast(&text), @ptrCast(&caption), 0);
+}
+
+fn toUtf16(comptime s: []const u8) [s.len:0]u16 {
+    var result: [s.len:0]u16 = undefined;
+    for (s, 0..) |c, i| result[i] = c;
+    result[s.len] = 0;
+    return result;
+}


### PR DESCRIPTION
Ports two Rust Win32 samples to Zig:

- **message_box** — `MessageBoxW` one-liner. Simplest possible Win32 GUI.
- **enum_windows** — `EnumWindows` + callback. Lists all visible window titles.

Both use `win_sys.project(.{...})` for selective API import.

`enum_windows` sample output (truncated):
```
Calendar | Billing and Portal ICM sync | Microsoft Teams
Task Manager
avs - Visual Studio Code
```

The `direct2d`, `counter`, and `device_watcher` samples need APIs/namespaces not yet fully surfaced in the Zig projection (D3D11/DXGI/D2D COM factories, PDH counters, DeviceWatcher events) — tracked for future work.