### PR TITLE
zig: port more Rust samples

### DIFF
--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1207,6 +1207,9 @@ pub fn build(b: *std.Build) void {
         \\    pub const System = struct {
         \\        pub const Threading = @import("Windows.System.Threading.zig");
         \\    };
+        \\    pub const Devices = struct {
+        \\        pub const Enumeration = @import("Windows.Devices.Enumeration.zig");
+        \\    };
         \\};
         \\
     ;
@@ -1416,6 +1419,15 @@ pub fn build(b: *std.Build) void {
         .{
             .name = "enum-windows",
             .root = "samples/enum_windows/main.zig",
+        },
+        .{
+            .name = "counter",
+            .root = "samples/counter/main.zig",
+        },
+        .{
+            .name = "device-watcher",
+            .root = "samples/device_watcher/main.zig",
+            .needs_win = true,
         },
     };
 

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -1429,6 +1429,11 @@ pub fn build(b: *std.Build) void {
             .root = "samples/device_watcher/main.zig",
             .needs_win = true,
         },
+        .{
+            .name = "minesweeper",
+            .root = "samples/minesweeper/main.zig",
+            .extra_libs = &.{ "user32", "gdi32" },
+        },
     };
 
     for (samples) |s| {

--- a/zig/packages/win-sys/src/project.zig
+++ b/zig/packages/win-sys/src/project.zig
@@ -148,6 +148,10 @@ pub const structs = struct {
     pub const WNDCLASSA =
         generated_structs.@"Windows.Win32.UI.WindowsAndMessaging".WNDCLASSA;
 
+    /// §windef.h. Common rectangle used by USER32/GDI paint and layout APIs.
+    pub const RECT =
+        generated_structs.@"Windows.Win32.Foundation".RECT;
+
     /// §winuser.h. Out-param of `GetMessageA` / `PeekMessageA`. Fed
     /// (by value) to `TranslateMessage` and `DispatchMessageA`.
     pub const MSG =

--- a/zig/samples/counter/main.zig
+++ b/zig/samples/counter/main.zig
@@ -49,7 +49,7 @@ pub fn main() void {
     };
 
     var counter: ?*anyopaque = null;
-    if (win.PdhAddCounterW(query, @constCast(@ptrCast(&counter_path)), 0, &counter) != 0) {
+    if (win.PdhAddCounterW(query, @ptrCast(@constCast(&counter_path)), 0, &counter) != 0) {
         std.debug.print("PdhAddCounterW failed\n", .{});
         return;
     }

--- a/zig/samples/counter/main.zig
+++ b/zig/samples/counter/main.zig
@@ -1,0 +1,71 @@
+//! Port of `crates/samples/windows/counter` — reads CPU usage via
+//! Performance Data Helper (PDH) in a loop.
+//!
+//! Exercises: Win32 PDH APIs, opaque handle types, extern union access.
+//!
+//! Build:  `zig build counter`
+//! Run:    `.\zig-out\bin\counter.exe`
+
+const std = @import("std");
+const win_sys = @import("win-sys");
+
+const win = win_sys.project(.{
+    .@"Windows.Win32.System.Performance" = .{
+        "PdhOpenQueryW",
+        "PdhAddCounterW",
+        "PdhCollectQueryData",
+        "PdhGetFormattedCounterValue",
+    },
+    .@"Windows.Win32.System.Threading" = .{"Sleep"},
+});
+
+// PDH handles are opaque (?*anyopaque aliases).
+// PDH_FMT_COUNTERVALUE is an extern struct with an Anonymous union.
+// We define the struct inline since it's not in the curated structs proxy.
+const PDH_FMT_COUNTERVALUE = extern struct {
+    CStatus: u32,
+    Anonymous: extern union {
+        longValue: i32,
+        doubleValue: f64,
+        largeValue: i64,
+    },
+};
+
+const PDH_FMT_DOUBLE: u32 = 512;
+
+pub fn main() void {
+    var query: ?*anyopaque = null;
+    if (win.PdhOpenQueryW(null, 0, &query) != 0) {
+        std.debug.print("PdhOpenQueryW failed\n", .{});
+        return;
+    }
+
+    const counter_path = comptime blk: {
+        const s = "\\Processor(0)\\% Processor Time";
+        var buf: [s.len:0]u16 = undefined;
+        for (s, 0..) |c, i| buf[i] = c;
+        buf[s.len] = 0;
+        break :blk buf;
+    };
+
+    var counter: ?*anyopaque = null;
+    if (win.PdhAddCounterW(query, @constCast(@ptrCast(&counter_path)), 0, &counter) != 0) {
+        std.debug.print("PdhAddCounterW failed\n", .{});
+        return;
+    }
+
+    std.debug.print("Reading CPU usage...\n", .{});
+
+    var i: u32 = 0;
+    while (i < 10) : (i += 1) {
+        win.Sleep(1000);
+        if (win.PdhCollectQueryData(query) != 0) continue;
+
+        var value: PDH_FMT_COUNTERVALUE = undefined;
+        @memset(std.mem.asBytes(&value), 0);
+        var counter_type: u32 = 0;
+        if (win.PdhGetFormattedCounterValue(counter, PDH_FMT_DOUBLE, &counter_type, @ptrCast(&value)) == 0) {
+            std.debug.print("{d:.2}%\n", .{value.Anonymous.doubleValue});
+        }
+    }
+}

--- a/zig/samples/device_watcher/main.zig
+++ b/zig/samples/device_watcher/main.zig
@@ -1,0 +1,127 @@
+//! Port of `crates/samples/windows/device_watcher` — enumerates
+//! devices using WinRT `DeviceWatcher` with event callbacks.
+//!
+//! Exercises: WinRT activation, COM delegate construction (cross-
+//! namespace `TypedEventHandler`), event registration via raw
+//! `add_Added` / `add_EnumerationCompleted` vtable slots.
+//!
+//! Build:  `zig build device-watcher`
+//! Run:    `.\zig-out\bin\device-watcher.exe`
+
+const std = @import("std");
+const win = @import("win");
+
+const core = win.core;
+const HRESULT = core.HRESULT;
+const GUID = core.GUID;
+const HSTRING = core.HSTRING;
+const Hstring = core.Hstring;
+
+const Devices = win.WinRT.Devices.Enumeration;
+const Foundation = win.WinRT.Foundation;
+
+/// TypedEventHandler<DeviceWatcher, DeviceInformation> Invoke signature.
+/// fn(this, sender: *DeviceWatcher, args: *DeviceInformation) -> HRESULT
+const AddedHandlerInvoke = fn (
+    this: *anyopaque,
+    sender: *anyopaque,
+    args: *anyopaque,
+) callconv(.winapi) HRESULT;
+
+/// TypedEventHandler<DeviceWatcher, object> Invoke for EnumerationCompleted.
+const CompletedHandlerInvoke = fn (
+    this: *anyopaque,
+    sender: *anyopaque,
+    args: *anyopaque,
+) callconv(.winapi) HRESULT;
+
+// IID for TypedEventHandler<DeviceWatcher, DeviceInformation>
+// {03c5a07b-990c-5d09-b0b8-5734eaa38222}
+const IID_AddedHandler = GUID.parse("03c5a07b-990c-5d09-b0b8-5734eaa38222");
+
+// IID for TypedEventHandler<DeviceWatcher, object>
+// {9234630f-1ff4-54f6-9e3f-ac20369b7725}
+const IID_CompletedHandler = GUID.parse("9234630f-1ff4-54f6-9e3f-ac20369b7725");
+
+fn onDeviceAdded(
+    _: *anyopaque,
+    _: *anyopaque,
+    args: *anyopaque,
+) callconv(.winapi) HRESULT {
+    // args is *IDeviceInformation — read its Name property.
+    const info: *const Devices.IDeviceInformation = @ptrCast(@alignCast(args));
+    var name: HSTRING = null;
+    const hr = info.get_Name(&name);
+    if (hr < 0) return hr;
+    var owned = Hstring.fromRaw(name);
+    defer owned.deinit();
+
+    var utf8_buf: [512]u8 = undefined;
+    const n = std.unicode.utf16LeToUtf8(&utf8_buf, owned.slice()) catch 0;
+    if (n > 0) {
+        std.debug.print("{s}\n", .{utf8_buf[0..n]});
+    }
+    return core.hresult.S_OK;
+}
+
+fn onEnumerationCompleted(
+    _: *anyopaque,
+    _: *anyopaque,
+    _: *anyopaque,
+) callconv(.winapi) HRESULT {
+    std.debug.print("done!\n", .{});
+    return core.hresult.S_OK;
+}
+
+pub fn main() !void {
+    try core.roInitialize(.multi_threaded);
+    defer core.winrt.RoUninitialize();
+
+    const allocator = std.heap.page_allocator;
+
+    // Get DeviceInformation statics and QI to IDeviceInformationStatics
+    // (which has CreateWatcher).
+    const statics2 = try Devices.DeviceInformation.statics();
+    defer statics2.deinit();
+
+    // QI for IDeviceInformationStatics (has CreateWatcher without filters).
+    var statics_ptr: ?*anyopaque = null;
+    try core.hresult.ok(statics2.vtbl().base.base.QueryInterface(
+        statics2.ptr,
+        &Devices.IDeviceInformationStatics.IID,
+        &statics_ptr,
+    ));
+    const statics: *const Devices.IDeviceInformationStatics = @ptrCast(@alignCast(statics_ptr.?));
+    defer _ = statics.Release();
+
+    // Create a DeviceWatcher.
+    var watcher: *Devices.IDeviceWatcher = undefined;
+    try core.hresult.ok(statics.CreateWatcher(@ptrCast(&watcher)));
+    defer _ = watcher.Release();
+
+    // Register Added handler.
+    const AddedDelegate = core.Delegate(AddedHandlerInvoke, IID_AddedHandler);
+    const added_handler = try AddedDelegate.create(allocator, &onDeviceAdded, null);
+    var added_token: Foundation.EventRegistrationToken = undefined;
+    @memset(std.mem.asBytes(&added_token), 0);
+    try core.hresult.ok(watcher.add_Added(added_handler, &added_token));
+    _ = AddedDelegate.release(added_handler);
+
+    // Register EnumerationCompleted handler.
+    const CompletedDelegate = core.Delegate(CompletedHandlerInvoke, IID_CompletedHandler);
+    const completed_handler = try CompletedDelegate.create(allocator, &onEnumerationCompleted, null);
+    var completed_token: Foundation.EventRegistrationToken = undefined;
+    @memset(std.mem.asBytes(&completed_token), 0);
+    try core.hresult.ok(watcher.add_EnumerationCompleted(completed_handler, &completed_token));
+    _ = CompletedDelegate.release(completed_handler);
+
+    // Start watching.
+    try core.hresult.ok(watcher.Start());
+
+    // Wait a few seconds for enumeration to complete.
+    std.debug.print("Enumerating devices for 5 seconds...\n", .{});
+    const Sleep = struct {
+        extern "kernel32" fn Sleep(dwMilliseconds: u32) callconv(.winapi) void;
+    }.Sleep;
+    Sleep(5000);
+}

--- a/zig/samples/minesweeper/main.zig
+++ b/zig/samples/minesweeper/main.zig
@@ -1,0 +1,300 @@
+//! Playable Zig port of robmikh/minesweeper-rs.
+//!
+//! The original sample renders with Windows.UI.Composition. This version
+//! ports the game, window, input, and render loop structure and draws the
+//! board with Win32/GDI so it exercises today's Win32 projection end-to-end.
+//!
+//! Build: `zig build samples`
+//! Run:   `.\zig-out\bin\minesweeper.exe`
+
+const std = @import("std");
+const win_sys = @import("win-sys");
+const game_mod = @import("minesweeper.zig");
+
+const win = win_sys.project(.{
+    .@"Windows.Win32.UI.WindowsAndMessaging" = .{
+        "RegisterClassA",
+        "CreateWindowExA",
+        "DefWindowProcA",
+        "GetMessageA",
+        "TranslateMessage",
+        "DispatchMessageA",
+        "PostQuitMessage",
+        "LoadCursorW",
+        "ShowWindow",
+        "SetWindowLongPtrA",
+        "GetWindowLongPtrA",
+    },
+    .@"Windows.Win32.System.LibraryLoader" = .{"GetModuleHandleA"},
+    .@"Windows.Win32.System.SystemInformation" = .{"GetTickCount64"},
+    .@"Windows.Win32.Graphics.Gdi" = .{
+        "FillRect",
+        "CreateSolidBrush",
+        "DeleteObject",
+        "TextOutA",
+        "SetBkMode",
+        "SetTextColor",
+        "InvalidateRect",
+        "UpdateWindow",
+    },
+});
+
+const WAM = win_sys.index.@"Windows.Win32.UI.WindowsAndMessaging";
+
+const tile = 28;
+const margin = 12;
+const header = 46;
+const client_width = margin * 2 + game_mod.width * tile;
+const client_height = header + margin + game_mod.height * tile;
+
+const PAINTSTRUCT = extern struct {
+    hdc: ?*anyopaque,
+    fErase: i32,
+    rcPaint: win_sys.structs.RECT,
+    fRestore: i32,
+    fIncUpdate: i32,
+    rgbReserved: [32]u8,
+};
+
+extern "USER32" fn BeginPaint(hwnd: ?*anyopaque, paint: *PAINTSTRUCT) callconv(.winapi) ?*anyopaque;
+extern "USER32" fn EndPaint(hwnd: ?*anyopaque, paint: *PAINTSTRUCT) callconv(.winapi) i32;
+
+const App = struct {
+    game: game_mod.Game,
+
+    fn init() App {
+        return .{ .game = game_mod.Game.init(seed()) };
+    }
+
+    fn restart(self: *App) void {
+        self.game.restart(seed());
+    }
+};
+
+fn seed() u64 {
+    const ticks = win.GetTickCount64();
+    return if (ticks == 0) 1 else ticks;
+}
+
+fn appFromWindow(hwnd: ?*anyopaque) ?*App {
+    const raw = win.GetWindowLongPtrA(hwnd, WAM.GWLP_USERDATA);
+    if (raw == 0) return null;
+    return @ptrFromInt(@as(usize, @intCast(raw)));
+}
+
+fn wndproc(
+    hwnd: ?*anyopaque,
+    message: u32,
+    wparam: usize,
+    lparam: isize,
+) callconv(.winapi) isize {
+    switch (message) {
+        WAM.WM_PAINT => {
+            if (appFromWindow(hwnd)) |app| {
+                var ps: PAINTSTRUCT = undefined;
+                @memset(std.mem.asBytes(&ps), 0);
+                const hdc = BeginPaint(hwnd, &ps);
+                if (hdc != null) {
+                    render(hdc, &app.game);
+                }
+                _ = EndPaint(hwnd, &ps);
+                return 0;
+            }
+        },
+        WAM.WM_LBUTTONDOWN => {
+            if (appFromWindow(hwnd)) |app| {
+                if (cellFromLparam(lparam)) |cell| {
+                    app.game.sweep(cell);
+                    _ = win.InvalidateRect(hwnd, null, 1);
+                }
+            }
+            return 0;
+        },
+        WAM.WM_RBUTTONDOWN => {
+            if (appFromWindow(hwnd)) |app| {
+                if (cellFromLparam(lparam)) |cell| {
+                    app.game.toggleFlag(cell);
+                    _ = win.InvalidateRect(hwnd, null, 1);
+                }
+            }
+            return 0;
+        },
+        WAM.WM_KEYDOWN => {
+            if (wparam == 'R' or wparam == 'r') {
+                if (appFromWindow(hwnd)) |app| {
+                    app.restart();
+                    _ = win.InvalidateRect(hwnd, null, 1);
+                }
+                return 0;
+            }
+        },
+        WAM.WM_DESTROY => {
+            win.PostQuitMessage(0);
+            return 0;
+        },
+        else => {},
+    }
+
+    return win.DefWindowProcA(hwnd, message, wparam, lparam);
+}
+
+fn cellFromLparam(lparam: isize) ?usize {
+    const bits: usize = @bitCast(lparam);
+    const x: i16 = @bitCast(@as(u16, @truncate(bits)));
+    const y: i16 = @bitCast(@as(u16, @truncate(bits >> 16)));
+
+    const board_x = @as(i32, margin);
+    const board_y = @as(i32, header);
+    const rel_x = @as(i32, x) - board_x;
+    const rel_y = @as(i32, y) - board_y;
+    if (rel_x < 0 or rel_y < 0) return null;
+
+    const col: usize = @intCast(@divTrunc(rel_x, tile));
+    const row: usize = @intCast(@divTrunc(rel_y, tile));
+    if (col >= game_mod.width or row >= game_mod.height) return null;
+    return game_mod.index(row, col);
+}
+
+fn render(hdc: ?*anyopaque, game: *const game_mod.Game) void {
+    fill(hdc, rect(0, 0, client_width, client_height), rgb(0x20, 0x23, 0x2a));
+
+    var status_buf: [128:0]u8 = undefined;
+    @memset(std.mem.asBytes(&status_buf), 0);
+    const status = switch (game.status) {
+        .playing => std.fmt.bufPrint(status_buf[0..status_buf.len], "Mines: {d}/{d}   Left opens, right flags, R restarts", .{
+            game.flags(),
+            game_mod.mine_count,
+        }) catch return,
+        .won => std.fmt.bufPrint(status_buf[0..status_buf.len], "You won! Press R to play again.", .{}) catch return,
+        .lost => std.fmt.bufPrint(status_buf[0..status_buf.len], "Boom! Press R to try again.", .{}) catch return,
+    };
+
+    _ = win.SetBkMode(hdc, 1);
+    _ = win.SetTextColor(hdc, rgb(0xf2, 0xf2, 0xf2));
+    _ = win.TextOutA(hdc, margin, 16, @ptrCast(&status_buf), @intCast(status.len));
+
+    for (game.cells, 0..) |cell, i| {
+        const row: i32 = @intCast(game_mod.rowOf(i));
+        const col: i32 = @intCast(game_mod.colOf(i));
+        const left = margin + col * tile;
+        const top = header + row * tile;
+        const cell_rect = rect(left, top, left + tile, top + tile);
+
+        if (cell.visible) {
+            fill(hdc, cell_rect, if (cell.mine) rgb(0xb8, 0x3a, 0x3a) else rgb(0xd5, 0xd9, 0xdf));
+            if (cell.mine) {
+                drawText(hdc, left + 9, top + 6, "X", rgb(0xff, 0xff, 0xff));
+            } else if (cell.neighbor_mines != 0) {
+                drawDigit(hdc, left + 10, top + 6, cell.neighbor_mines);
+            }
+        } else if (cell.flagged) {
+            fill(hdc, cell_rect, rgb(0xe7, 0xb4, 0x4b));
+            drawText(hdc, left + 10, top + 6, "F", rgb(0x22, 0x22, 0x22));
+        } else {
+            fill(hdc, cell_rect, rgb(0x59, 0x66, 0x75));
+        }
+
+        border(hdc, cell_rect, rgb(0x17, 0x19, 0x1f));
+    }
+}
+
+fn drawDigit(hdc: ?*anyopaque, x: i32, y: i32, value: u8) void {
+    const color = switch (value) {
+        1 => rgb(0x24, 0x5e, 0xc4),
+        2 => rgb(0x25, 0x7a, 0x39),
+        3 => rgb(0xb5, 0x32, 0x2d),
+        4 => rgb(0x55, 0x34, 0xa5),
+        else => rgb(0x1d, 0x1d, 0x1d),
+    };
+
+    var buf = "0".*;
+    buf[0] = '0' + value;
+    _ = win.SetTextColor(hdc, color);
+    _ = win.TextOutA(hdc, x, y, &buf, 1);
+}
+
+fn drawText(hdc: ?*anyopaque, x: i32, y: i32, comptime text: []const u8, color: u32) void {
+    var buf = (text ++ "\x00").*;
+    _ = win.SetTextColor(hdc, color);
+    _ = win.TextOutA(hdc, x, y, &buf, text.len);
+}
+
+fn border(hdc: ?*anyopaque, r: win_sys.structs.RECT, color: u32) void {
+    fill(hdc, rect(r.left, r.top, r.right, r.top + 1), color);
+    fill(hdc, rect(r.left, r.bottom - 1, r.right, r.bottom), color);
+    fill(hdc, rect(r.left, r.top, r.left + 1, r.bottom), color);
+    fill(hdc, rect(r.right - 1, r.top, r.right, r.bottom), color);
+}
+
+fn fill(hdc: ?*anyopaque, r: win_sys.structs.RECT, color: u32) void {
+    const brush = win.CreateSolidBrush(color);
+    if (brush == null) return;
+    defer _ = win.DeleteObject(brush);
+    var mutable_rect = r;
+    _ = win.FillRect(hdc, &mutable_rect, brush);
+}
+
+fn rect(left: i32, top: i32, right: i32, bottom: i32) win_sys.structs.RECT {
+    return .{
+        .left = left,
+        .top = top,
+        .right = right,
+        .bottom = bottom,
+    };
+}
+
+fn rgb(r: u8, g: u8, b: u8) u32 {
+    return @as(u32, r) | (@as(u32, g) << 8) | (@as(u32, b) << 16);
+}
+
+pub fn main() !void {
+    const instance = win.GetModuleHandleA(null);
+    if (instance == null) return error.GetModuleHandleFailed;
+
+    var app = App.init();
+
+    var class_name = "zig-minesweeper".*;
+    const class_name_ptr: ?[*:0]u8 = &class_name;
+
+    var wc: win_sys.structs.WNDCLASSA = undefined;
+    @memset(std.mem.asBytes(&wc), 0);
+    wc.style = WAM.CS_HREDRAW | WAM.CS_VREDRAW;
+    wc.lpfnWndProc = @ptrCast(&wndproc);
+    wc.hInstance = .{ .Value = instance.? };
+    const idc_arrow: ?[*:0]u16 = @ptrFromInt(@as(usize, WAM.IDC_ARROW));
+    const cursor = win.LoadCursorW(null, idc_arrow);
+    if (cursor != null) wc.hCursor = .{ .Value = cursor.? };
+    wc.lpszClassName = .{ .Value = @ptrCast(&class_name) };
+
+    const atom = win.RegisterClassA(&wc);
+    if (atom == 0) return error.RegisterClassFailed;
+
+    var title = "Zig Minesweeper".*;
+    const title_ptr: ?[*:0]u8 = &title;
+    const hwnd = win.CreateWindowExA(
+        0,
+        class_name_ptr,
+        title_ptr,
+        WAM.WS_OVERLAPPEDWINDOW | WAM.WS_VISIBLE,
+        WAM.CW_USEDEFAULT,
+        WAM.CW_USEDEFAULT,
+        client_width + 18,
+        client_height + 46,
+        null,
+        null,
+        instance,
+        null,
+    );
+    if (hwnd == null) return error.CreateWindowFailed;
+
+    _ = win.SetWindowLongPtrA(hwnd, WAM.GWLP_USERDATA, @intCast(@intFromPtr(&app)));
+    _ = win.ShowWindow(hwnd, WAM.SW_SHOW);
+    _ = win.UpdateWindow(hwnd);
+
+    var message: win_sys.structs.MSG = undefined;
+    @memset(std.mem.asBytes(&message), 0);
+    while (win.GetMessageA(&message, null, 0, 0) != 0) {
+        _ = win.TranslateMessage(&message);
+        _ = win.DispatchMessageA(&message);
+    }
+}

--- a/zig/samples/minesweeper/minesweeper.zig
+++ b/zig/samples/minesweeper/minesweeper.zig
@@ -1,0 +1,236 @@
+const std = @import("std");
+
+pub const width = 16;
+pub const height = 16;
+pub const mine_count = 40;
+pub const cell_count = width * height;
+
+pub const Status = enum {
+    playing,
+    won,
+    lost,
+};
+
+pub const Cell = struct {
+    mine: bool = false,
+    visible: bool = false,
+    flagged: bool = false,
+    neighbor_mines: u8 = 0,
+};
+
+pub const Game = struct {
+    cells: [cell_count]Cell,
+    generated: bool,
+    status: Status,
+    remaining_safe: u16,
+    rng: std.Random.DefaultPrng,
+
+    pub fn init(seed: u64) Game {
+        return .{
+            .cells = [_]Cell{.{}} ** cell_count,
+            .generated = false,
+            .status = .playing,
+            .remaining_safe = cell_count - mine_count,
+            .rng = std.Random.DefaultPrng.init(seed),
+        };
+    }
+
+    pub fn restart(self: *Game, seed: u64) void {
+        self.* = init(seed);
+    }
+
+    pub fn toggleFlag(self: *Game, cell_index: usize) void {
+        if (self.status != .playing) return;
+        if (cell_index >= cell_count) return;
+
+        var cell = &self.cells[cell_index];
+        if (cell.visible) return;
+        cell.flagged = !cell.flagged;
+    }
+
+    pub fn sweep(self: *Game, cell_index: usize) void {
+        if (self.status != .playing) return;
+        if (cell_index >= cell_count) return;
+        if (self.cells[cell_index].flagged or self.cells[cell_index].visible) return;
+
+        if (!self.generated) {
+            self.generate(cell_index);
+        }
+
+        if (self.cells[cell_index].mine) {
+            self.cells[cell_index].visible = true;
+            self.revealMines();
+            self.status = .lost;
+            return;
+        }
+
+        self.revealRegion(cell_index);
+        if (self.remaining_safe == 0) {
+            self.status = .won;
+            for (&self.cells) |*cell| {
+                if (cell.mine) cell.flagged = true;
+            }
+        }
+    }
+
+    pub fn flags(self: *const Game) u16 {
+        var total: u16 = 0;
+        for (self.cells) |cell| {
+            if (cell.flagged) total += 1;
+        }
+        return total;
+    }
+
+    pub fn mineTotal(self: *const Game) u16 {
+        var total: u16 = 0;
+        for (self.cells) |cell| {
+            if (cell.mine) total += 1;
+        }
+        return total;
+    }
+
+    fn generate(self: *Game, first_sweep: usize) void {
+        var candidates: [cell_count - 1]u16 = undefined;
+        var len: usize = 0;
+        for (0..cell_count) |i| {
+            if (i == first_sweep) continue;
+            candidates[len] = @intCast(i);
+            len += 1;
+        }
+
+        var random = self.rng.random();
+        random.shuffle(u16, candidates[0..len]);
+
+        for (candidates[0..mine_count]) |candidate| {
+            self.cells[candidate].mine = true;
+        }
+
+        for (0..cell_count) |i| {
+            if (!self.cells[i].mine) {
+                self.cells[i].neighbor_mines = self.countNeighborMines(i);
+            }
+        }
+
+        self.generated = true;
+    }
+
+    fn countNeighborMines(self: *const Game, cell_index: usize) u8 {
+        var total: u8 = 0;
+        var neighbors = NeighborIterator.init(cell_index);
+        while (neighbors.next()) |neighbor| {
+            if (self.cells[neighbor].mine) total += 1;
+        }
+        return total;
+    }
+
+    fn revealRegion(self: *Game, cell_index: usize) void {
+        var stack: [cell_count]usize = undefined;
+        var stack_len: usize = 0;
+
+        self.revealSafeCell(cell_index, &stack, &stack_len);
+        while (stack_len > 0) {
+            stack_len -= 1;
+            const current = stack[stack_len];
+
+            var neighbors = NeighborIterator.init(current);
+            while (neighbors.next()) |neighbor| {
+                self.revealSafeCell(neighbor, &stack, &stack_len);
+            }
+        }
+    }
+
+    fn revealSafeCell(
+        self: *Game,
+        cell_index: usize,
+        stack: *[cell_count]usize,
+        stack_len: *usize,
+    ) void {
+        var cell = &self.cells[cell_index];
+        if (cell.visible or cell.flagged or cell.mine) return;
+
+        cell.visible = true;
+        self.remaining_safe -= 1;
+
+        if (cell.neighbor_mines == 0) {
+            stack[stack_len.*] = cell_index;
+            stack_len.* += 1;
+        }
+    }
+
+    fn revealMines(self: *Game) void {
+        for (&self.cells) |*cell| {
+            if (cell.mine) cell.visible = true;
+        }
+    }
+};
+
+pub fn index(row: usize, col: usize) usize {
+    return row * width + col;
+}
+
+pub fn rowOf(cell_index: usize) usize {
+    return cell_index / width;
+}
+
+pub fn colOf(cell_index: usize) usize {
+    return cell_index % width;
+}
+
+const NeighborIterator = struct {
+    row: i32,
+    col: i32,
+    next_slot: usize,
+
+    const offsets = [_][2]i32{
+        .{ -1, -1 },
+        .{ -1, 0 },
+        .{ -1, 1 },
+        .{ 0, -1 },
+        .{ 0, 1 },
+        .{ 1, -1 },
+        .{ 1, 0 },
+        .{ 1, 1 },
+    };
+
+    fn init(cell_index: usize) NeighborIterator {
+        return .{
+            .row = @intCast(rowOf(cell_index)),
+            .col = @intCast(colOf(cell_index)),
+            .next_slot = 0,
+        };
+    }
+
+    fn next(self: *NeighborIterator) ?usize {
+        while (self.next_slot < offsets.len) : (self.next_slot += 1) {
+            const offset = offsets[self.next_slot];
+            const row = self.row + offset[0];
+            const col = self.col + offset[1];
+            if (row < 0 or row >= height or col < 0 or col >= width) continue;
+
+            self.next_slot += 1;
+            return index(@intCast(row), @intCast(col));
+        }
+        return null;
+    }
+};
+
+test "first sweep places the requested mine count and spares the clicked cell" {
+    var game = Game.init(1234);
+    game.sweep(index(4, 4));
+
+    try std.testing.expect(game.generated);
+    try std.testing.expect(!game.cells[index(4, 4)].mine);
+    try std.testing.expectEqual(@as(u16, mine_count), game.mineTotal());
+}
+
+test "flagged cells do not sweep" {
+    var game = Game.init(1);
+    const target = index(0, 0);
+
+    game.toggleFlag(target);
+    game.sweep(target);
+
+    try std.testing.expect(!game.generated);
+    try std.testing.expect(game.cells[target].flagged);
+    try std.testing.expect(!game.cells[target].visible);
+}


### PR DESCRIPTION
Ports three Zig samples from Rust sample coverage:

**counter** (#36) — Win32 PDH performance counters. Reads CPU usage in a loop.

**device_watcher** (#37) — WinRT `DeviceWatcher` with `TypedEventHandler` events. Exercises cross-namespace COM delegate construction, WinRT activation, and QI.

**minesweeper** (#38) — playable minesweeper sample based on `robmikh/minesweeper-rs`: pure game state, Win32 window/input loop, and Win32/GDI board rendering. This intentionally keeps the first port buildable on today's projection; Windows.UI.Composition renderer parity remains a follow-up for issue #38.

Validation:
- `zig test samples\minesweeper\minesweeper.zig`
- `zig build test`
- smoke-launched `zig-out\bin\minesweeper.exe`

Refs #36, #37, #38.